### PR TITLE
Description of preConnections / prePlugins methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Glue exports a single function `compose` accepting a JSON `manifest` file specif
         * `options` - an object to use as the plugin options which get passed to the plugin's registration function when called.
   + `options` - an object having
     * 'relativeTo' - a file-system path string that is used to resolve loading modules with `require`.  Used in `server.cache` and `plugins[name]`
-    * 'preConnections' - a callback function that is called prior to adding connections to the server. The function signature is `function (server)` where:
+    * 'preConnections' - a callback function that is called prior to adding connections to the server. The function signature is `function (server, next)` where:
       + `server` - is the server object returned from `new Server(options)`.
-    * 'prePlugins' - a callback function that is called prior to registering plugins with the server. The function signature is `function (server)` where:
+      + `next`-  the callback function the method must call to return control over to glue 
+    * 'prePlugins' - a callback function that is called prior to registering plugins with the server. The function signature is `function (server, next)` where:
       + `server` - is the server object with all connections selected.
+      + `next`-  the callback function the method must call to return control over to glue 
   + `callback` - the callback function with signature `function (err, server)` where:
     * `err` - the error response if a failure occurred, otherwise `null`.
     * `server` - the server object. Call `server.start()` to actually start the server.


### PR DESCRIPTION
Add the description of the 'next' parameter required to return control to glue.