### PR TITLE
Glue Documentation Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Lead Maintainer - [Chris Rempel](https://github.com/csrl)
 
 ## Overview
 
-Glue is a hapijs application composer which utilizes a JSON object called `manifest` to define how an 
-application is composed. The manifest object defines server options, connections, and plugin 
-registrations.  All major configurations are defined in one object named: `manifest`.  
+Glue is a hapijs application composer which utilizes a JSON object called `manifest` to compose 
+an application. The manifest defines server options, connections, and plugin 
+registrations.  All major configurations are defined in this object.  
 
  
 ## Interface
@@ -43,12 +43,9 @@ Glue exports a single function `compose` accepting the JSON `manifest` file spec
 
 When using glue to bootstrap an application there is a small gotcha regarding plugin load order.  
 V8 will not guarantee JSON object elements are loaded in the sequential order defined in the object. 
-Hence, if your plugin relies on a dependecy previously declared you may get a dependency does not exist 
-error when starting the application.
-
-The below does not work because the attributes.dependencies key just means that the server will at some point have loaded the other.
-It specifies that it must exist eventually, not that it must exist before your plugin. It will not cause a problem if you 
-declare a dependency here. It just does not guarantee it will be loaded first. 
+Hence, if a plugin relies on a dependecy previously declared in the `manifest`, the dependency may not be loaded first causing errors. 
+If you set the attributes.dependencies key it just specifies that dependencies must eventually exist, but does not require  
+they exist before your plugin. In short, the below does not guarantee dependencies will be loaded first. 
 
 ```
 register.attributes = {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Hence, if a plugin relies on a dependecy previously declared in the `manifest`, 
 If you set the attributes.dependencies key, it just specifies that dependencies must eventually exist, but does not require  
 they exist before your plugin. So, the below does not guarantee dependencies are loaded first. 
 
-```
+``` JavaScript
 register.attributes = {
     name: 'Auth',
     dependencies:'haps-auth-basic' 
@@ -105,22 +105,19 @@ register.attributes = {
   * Pros: 
     * Solution is airtight.  
     * This is the preferred hapijs solution.
-    * Just declare the plugin in the manifest.plugins JSON object. 
-    * Then in plugins that have dependencies, use server.dependency(dependencies, after) logic 
-      to ensure dependencies are loaded first. 
+    * No accounting needed
     * Easy to read: Every plugin with dependecies has them clearly defined at the 
       top of the plugin. 
   * Cons:
-    * Plugins with dependencies code is a little more verbose.  
-    * Developer has to write a little more code.
+    * More verbose.  
   * Documentation: [`server.dependecy(dependencies, [after])`](http://hapijs.com/api#serverdependencydependencies-after)
     
 
-## Example of a Plugin  Declarating Dependencies
+## Example of a Plugin  Declaring Dependencies
 
 Bullet proof solution from  @FennNaten 's example below:
 
-```
+``` JavaScript
 internals = {};
 
 exports.register = function (server, options, next) {
@@ -155,4 +152,4 @@ Glue primarily works in synergy with [Rejoice](https://github.com/hapijs/rejoice
 See his explanations:<br/>
 [Testing Glue Dependency Logic](https://github.com/hapijs/university/pull/137)<br/>
 [Mark Strategies as Dependant](https://github.com/jedireza/aqua/issues/36)<br/>
-@nlf gitter conversation<br/>
+@nlf added clarification in gitter conversation<br/>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ Server composer for hapi.js.
 
 Lead Maintainer - [Chris Rempel](https://github.com/csrl)
 
+## Overview
+
+Glue is a hapijs application composer which utilizes a JSON object called `manifest` to define how an 
+application is composed. The manifest object defines server options, connections, and plugin 
+registrations.  All major configurations are defined in one object named: `manifest`.  
+
+ 
 ## Interface
 
-Glue exports a single function `compose` accepting a JSON `manifest` file specifying the Hapi server options, connections and plugins.  Glue primarily works in synergy with [Rejoice](https://github.com/hapijs/rejoice), but can be integrated directly into any Hapi application loader.
+Glue exports a single function `compose` accepting the JSON `manifest` file specifying the Hapi server options, connections and plugins.  
 
 - `compose(manifest, [options], callback)`
   + `manifest` - an object having:
@@ -30,6 +37,56 @@ Glue exports a single function `compose` accepting a JSON `manifest` file specif
   + `callback` - the callback function with signature `function (err, server)` where:
     * `err` - the error response if a failure occurred, otherwise `null`.
     * `server` - the server object. Call `server.start()` to actually start the server.
+
+
+## Guaranteeing Plugin Load Order 
+
+When using glue to bootstrap an application there is a small gotcha regarding plugin load order.  
+V8 will not guarantee JSON object elements are loaded in the sequential order defined in the object. 
+Hence, if your plugin relies on a dependecy previously declared you may get a dependency does not exist 
+error when starting the application.
+
+The below does not work because the attributes.dependencies key just means that the server will at some point have loaded the other.
+It specifies that it must exist eventually, not that it must exist before your plugin. It will not cause a problem if you 
+declare a dependency here. It just does not guarantee it will be loaded first. 
+
+```
+register.attributes = {
+    name: 'Auth',
+    dependencies:'haps-auth-basic' 
+};
+```
+
+### Solutions
+
++ Quick Solution  
+  * Make the value of the manifest.plugins key an array.  
+    If the key is an array the plugins will be loaded in the sequence of the array.  
+  *  Pros: 
+    * Can quickly configure you apps plugin load order.
+    * You do not have to declare dependencies inside other plugins. 
+  *  Cons: 
+    * If the order of plugins is changed in the array, it would break the application.
+    * Developer must do accounting to determine which plugin needs what dependency. 
+    * Not an air tight solution. 
+
++ Bullet Proof Solution  
+  * Make manifest.plugins key a JSON object listing plugins to register and use 
+    server.dependency(dependencies, [after]) in plugins to declare dependencies. 
+  * Documentation: [`server.dependecy(dependencies, [after])`](http://hapijs.com/api#serverdependencydependencies-after)
+  * Example solution: [@FennNaten Example](https://github.com/FennNaten/aqua/blob/sample/setting-deps-via-server-register/server/auth.js)
+  * Pros: 
+    * Solution is airtight.  
+    * This is the preferred hapijs solution.
+    * Just declare the plugin in the manifest.plugins JSON object. 
+    * Then in plugins that have dependencies, use server.dependency(dependencies, after) logic 
+      to ensure dependencies are loaded first. 
+    * Easy to read: Every plugin with dependecies has them clearly defined at the 
+      top of the plugin. 
+  * Cons:
+    * Plugins with dependencies code is a little more verbose.  
+    * Developer has to write a little more code.
+    
 
 ## Usage
 
@@ -67,3 +124,43 @@ Glue.compose(manifest, options, function (err, server) {
     });
 });
 ```
+
+
+## Sample Declaration of Plugin Dependencies
+
+Below is bullet proof solution from  @FennNaten 's example:
+[@FennNaten 's Fork of aqua](https://github.com/FennNaten/aqua/blob/sample/setting-deps-via-server-register/server/auth.js)
+```
+internals = {};
+
+exports.register = function (server, options, next) {
+
+    // the registration logic in internals.after will be executed on server start, 
+    // and only after dependencies are fully registered. 
+    server.dependency(['hapi-auth-cookie', 'hapi-mongo-models'], internals.after);
+
+    next();
+};
+
+// all the registration logic depends on other plugins (uses schemes and plugins-specific space), 
+// so we extract it so that we can set it up to be fired only after dependency resolution
+internals.after = function(server, next){
+
+    var Session = server.plugins['hapi-mongo-models'].Session;
+    var User = server.plugins['hapi-mongo-models'].User;
+
+    // Plugin code here.
+
+    next();
+};
+
+```
+
+## Other notes
+Glue primarily works in synergy with [Rejoice](https://github.com/hapijs/rejoice), but can be integrated directly into any Hapi application loader.
+
+## Sources 
+@nlf gitter conversation
+@FennNaten did serious testing on Glue and plugin dependency logic see his explanations:
+[Testing Glue Dependency Logic](https://github.com/hapijs/university/pull/137)
+[Mark Strategies as Dependant](https://github.com/jedireza/aqua/issues/36)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ Server composer for hapi.js.
 
 Lead Maintainer - [Chris Rempel](https://github.com/csrl)
 
-## Overview
-
-Glue is a hapijs application composer which utilizes a JSON object called `manifest` to compose 
-an application. The manifest defines server options, connections, and plugin 
-registrations.  All major configurations are defined in this object.  
-
  
 ## Interface
 
@@ -42,7 +36,7 @@ Glue exports a single function `compose` accepting the JSON `manifest` file spec
 
 ## Usage
 
-You create a manifest and then you can use the manifest for creating the new server:
+You write a manifest and use it to create a new server:
 
 ```javascript
 var Glue = require('glue');
@@ -81,9 +75,9 @@ Glue.compose(manifest, options, function (err, server) {
 
 When using glue to bootstrap an application there is a small gotcha regarding plugin load order and dependencies.  
 V8 will not guarantee JSON object elements are loaded in the sequential order defined in the object. 
-Hence, if a plugin relies on a dependecy previously declared in the `manifest`, the dependency may not be loaded first causing errors. 
-If you set the attributes.dependencies key it just specifies that dependencies must eventually exist, but does not require  
-they exist before your plugin. In short, the below does not guarantee dependencies will be loaded first. 
+Hence, if a plugin relies on a dependecy previously declared in the `manifest`, that dependency may not be loaded first causing errors. 
+If you set the attributes.dependencies key, it just specifies that dependencies must eventually exist, but does not require  
+they exist before your plugin. So, the below does not guarantee dependencies are loaded first. 
 
 ```
 register.attributes = {
@@ -96,20 +90,18 @@ register.attributes = {
 
 + Quick Solution  
   * Make the value of the manifest.plugins key an array.  
-    If the key is an array the plugins will be loaded in the sequence of the array.  
+    If the key is an array, the plugins will be loaded in the sequence of the array.  
   *  Pros: 
-    * Quickly configure your apps plugin load order.
+    * Quickly configure application plugin load order.
     * Do not have to declare dependencies inside other plugins. 
   *  Cons: 
-    * If order of plugins is changed in the array, it could break the application.
-    * Must do accounting to correctly order plugins defined in the array. 
+    * If array has incorrect order of plugins, it will break the application.
+    * Must do accounting to ensure correct order. 
 
 + Bullet Proof Solution  
-  * Make manifest.plugins key a JSON object listing plugins in any order to be registered. Plus, inside 
-    plugins with dependencies use `server.dependency(dependencies, [after])` logic to declare dependencies and ensure 
-    depencies are loaded first.
-  * Documentation: [`server.dependecy(dependencies, [after])`](http://hapijs.com/api#serverdependencydependencies-after)
-  * Example solution: [@FennNaten Example](https://github.com/FennNaten/aqua/blob/sample/setting-deps-via-server-register/server/auth.js)
+  * Make manifest.plugins key a JSON object listing plugins registered. Then, inside 
+    plugins with dependencies use `server.dependency(dependencies, [after])` logic to ensure 
+    depencies are loaded first. Note, with this method the order plugins are listed in the JSON object is irrelevant.
   * Pros: 
     * Solution is airtight.  
     * This is the preferred hapijs solution.
@@ -121,12 +113,12 @@ register.attributes = {
   * Cons:
     * Plugins with dependencies code is a little more verbose.  
     * Developer has to write a little more code.
+  * Documentation: [`server.dependecy(dependencies, [after])`](http://hapijs.com/api#serverdependencydependencies-after)
     
 
 ## Example of a Plugin  Declarating Dependencies
 
-Below is bullet proof solution from  @FennNaten 's example:
-[@FennNaten 's Fork of aqua](https://github.com/FennNaten/aqua/blob/sample/setting-deps-via-server-register/server/auth.js)
+Bullet proof solution from  @FennNaten 's example below:
 
 ```
 internals = {};
@@ -153,6 +145,7 @@ internals.after = function(server, next){
 };
 
 ```
+Source for above sample code [@FennNaten 's Fork of aqua](https://github.com/FennNaten/aqua/blob/sample/setting-deps-via-server-register/server/auth.js)
 
 ## Other notes
 Glue primarily works in synergy with [Rejoice](https://github.com/hapijs/rejoice), but can be integrated directly into any Hapi application loader.


### PR DESCRIPTION
Explained how to navigate plugin dependency loading issues when using Glue.
Explained strengths and weaknesses of setting an Array or JSON object 
at the manifest.plugins key.  Plus, gave an example of how to properly declare dependencies
with server.dependency(dependencies, [after]).