### PR TITLE
Allow to specify custom server instance in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Glue exports a single function `compose` accepting a JSON `manifest` file specif
     * 'prePlugins' - a callback function that is called prior to registering plugins with the server. The function signature is `function (server, next)` where:
       + `server` - is the server object with all connections selected.
       + `next`-  the callback function the method must call to return control over to glue
+    * 'server' - a custom server instance to use for this manifest. You cannot specify any server options in the manifest, when using this option.
   + `callback` - the callback function with signature `function (err, server)` where:
     * `err` - the error response if a failure occurred, otherwise `null`.
     * `server` - the server object. Call `server.start()` to actually start the server.

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,9 @@ exports.compose = function (manifest /*, [options], callback */) {
             });
         }
         else {
-            server.connection();
+            if (server.connections.length === 0) {
+                server.connection();
+            }
         }
 
         next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,8 @@ exports.compose = function (manifest /*, [options], callback */) {
     var serverOpts = internals.parseServer(manifest.server || {}, options.relativeTo);
     var server = options.server || new Hapi.Server(serverOpts);
 
+    Hoek.assert(!options.server || Object.keys(serverOpts).length === 0, 'Server options not used for custom server instance');
+
     var steps = [];
     steps.push(function (next) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ internals.schema = {
     options: Joi.object({
         relativeTo: Joi.string(),
         preConnections: Joi.func().allow(false),
-        prePlugins: Joi.func().allow(false)
+        prePlugins: Joi.func().allow(false),
+        server: Joi.object()
     }),
     manifest: Joi.object({
         server: Joi.object(),
@@ -77,7 +78,7 @@ exports.compose = function (manifest /*, [options], callback */) {
     // Create server
 
     var serverOpts = internals.parseServer(manifest.server || {}, options.relativeTo);
-    var server = new Hapi.Server(serverOpts);
+    var server = options.server || new Hapi.Server(serverOpts);
 
     var steps = [];
     steps.push(function (next) {

--- a/test/index.js
+++ b/test/index.js
@@ -321,6 +321,25 @@ describe('compose()', function () {
         });
     });
 
+    it('composes server with server instance', function (done) {
+
+        var Hapi = require('hapi');
+        var customServer = new Hapi.Server();
+
+        var manifest = {};
+        var options = {
+            server: customServer
+        };
+
+        Glue.compose(manifest, options, function (err, server) {
+
+            expect(err).to.not.exist();
+            expect(server).to.equal(customServer);
+            done();
+        });
+
+    });
+
     it('errors on failed pre handler', function (done) {
 
         var manifest = {};

--- a/test/index.js
+++ b/test/index.js
@@ -322,11 +322,19 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with server instance', function (done) {
+    it('composes server with custom server instance', function (done) {
 
         var customServer = new Hapi.Server();
 
-        var manifest = {};
+        var manifest = {
+            connections: [
+                { labels: 'a' },
+                { labels: 'b' }
+            ],
+            plugins: {
+                '../test/plugins/helloworld.js': null
+            }
+        };
         var options = {
             server: customServer
         };
@@ -335,6 +343,9 @@ describe('compose()', function () {
 
             expect(err).to.not.exist();
             expect(server).to.equal(customServer);
+            expect(server.connections).length(2);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello).to.equal('world');
             done();
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 var Code = require('code');
 var Glue = require('..');
+var Hapi = require('hapi');
 var Lab = require('lab');
 
 
@@ -323,7 +324,6 @@ describe('compose()', function () {
 
     it('composes server with server instance', function (done) {
 
-        var Hapi = require('hapi');
         var customServer = new Hapi.Server();
 
         var manifest = {};
@@ -337,12 +337,10 @@ describe('compose()', function () {
             expect(server).to.equal(customServer);
             done();
         });
-
     });
 
     it('throws on options.server when server options given (manifest.server)', function (done) {
 
-        var Hapi = require('hapi');
         var customServer = new Hapi.Server();
 
         var manifest = {

--- a/test/index.js
+++ b/test/index.js
@@ -340,6 +340,27 @@ describe('compose()', function () {
 
     });
 
+    it('throws on options.server when server options given (manifest.server)', function (done) {
+
+        var Hapi = require('hapi');
+        var customServer = new Hapi.Server();
+
+        var manifest = {
+            server: {
+                cache: '../node_modules/catbox-memory'
+            }
+        };
+        var options = {
+            server: customServer
+        };
+
+        expect(function () {
+
+            Glue.compose(manifest, { server: customServer }, function () { });
+        }).to.throw(/Server options not used for custom server instance/);
+        done();
+    });
+
     it('errors on failed pre handler', function (done) {
 
         var manifest = {};

--- a/test/index.js
+++ b/test/index.js
@@ -392,6 +392,33 @@ describe('compose()', function () {
         });
     });
 
+    it('does not overwrite configuration of custom server instance', function (done) {
+
+        var customServer = new Hapi.Server();
+        customServer.connection({ labels: 'a' });
+        customServer.connection({ labels: 'b' });
+
+        var manifest = {};
+        var options = {
+            server: customServer
+        };
+
+        customServer.register(require('../test/plugins/helloworld.js'), function (err) {
+
+            expect(err).to.not.exist();
+
+            Glue.compose(manifest, options, function (err, server) {
+
+                expect(err).to.not.exist();
+                expect(server).to.equal(customServer);
+                expect(server.connections).length(2);
+                expect(server.plugins.helloworld).to.exist();
+                expect(server.plugins.helloworld.hello).to.equal('world');
+                done();
+            });
+        });
+    });
+
     it('throws on options.server when server options given (manifest.server)', function (done) {
 
         var customServer = new Hapi.Server();


### PR DESCRIPTION
This pull request adds `option.server`, which accepts a custom server instance to be used. The `manifest.server` is not allowed to be specified along with `option.server`.

My use case for creating this pull request:

1. I want to be able to specify the exact version of Hapi in my `package.json`. I can do this now and pass the server instance to Glue.
2. I want to export my server instance for unit tests synchronously, before Glue has done its work. I can do this by creating the server instance, export it, and pass it to Glue to do the magic.

Any comments/feedback is appreciated.