### PR TITLE
allow Hapi v11.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "boom": "2.x.x",
-    "hapi": "8.x.x || 9.x.x || 10.x.x",
+    "hapi": "8.x.x || 9.x.x || 10.x.x || 11.x.x",
     "hoek": "2.x.x",
     "items": "1.x.x",
     "joi": "5.x.x || 6.x.x"


### PR DESCRIPTION
`npm test` passes, but it's unclear if these tests integrate with Hapi at all.