### PR TITLE
update to es6 based hapi style guide and lab 7 + Dependencies update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
+  - "4.0"
+  - "4"
+  - "5"
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,16 @@
+'use strict';
 // Load modules
 
-var Path = require('path');
-var Hapi = require('hapi');
-var Hoek = require('hoek');
-var Items = require('items');
-var Joi = require('joi');
+const Path = require('path');
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Items = require('items');
+const Joi = require('joi');
 
 
 // Declare internals
 
-var internals = {};
+const internals = {};
 
 
 internals.schema = {
@@ -28,8 +29,8 @@ internals.schema = {
 
 exports.compose = function (manifest /*, [options], callback */) {
 
-    var options = arguments.length === 2 ? {} : arguments[1];
-    var callback = arguments.length === 2 ? arguments[1] : arguments[2];
+    const options = arguments.length === 2 ? {} : arguments[1];
+    const callback = arguments.length === 2 ? arguments[1] : arguments[2];
 
     Hoek.assert(typeof callback === 'function', 'Invalid callback');
     Joi.assert(options, internals.schema.options, 'Invalid options');
@@ -37,11 +38,11 @@ exports.compose = function (manifest /*, [options], callback */) {
 
     // Create server
 
-    var serverOpts = internals.parseServer(manifest.server || {}, options.relativeTo);
-    var server = new Hapi.Server(serverOpts);
+    const serverOpts = internals.parseServer(manifest.server || {}, options.relativeTo);
+    const server = new Hapi.Server(serverOpts);
 
-    var steps = [];
-    steps.push(function (next) {
+    const steps = [];
+    steps.push((next) => {
 
         if (options.preConnections) {
             options.preConnections(server, next);
@@ -51,12 +52,12 @@ exports.compose = function (manifest /*, [options], callback */) {
         }
     });
 
-    steps.push(function (next) {
+    steps.push((next) => {
 
         // Load connections
 
         if (manifest.connections) {
-            manifest.connections.forEach(function (connection) {
+            manifest.connections.forEach((connection) => {
 
                 server.connection(connection);
             });
@@ -68,7 +69,7 @@ exports.compose = function (manifest /*, [options], callback */) {
         next();
     });
 
-    steps.push(function (next) {
+    steps.push((next) => {
 
         if (options.prePlugins) {
             options.prePlugins(server, next);
@@ -78,17 +79,17 @@ exports.compose = function (manifest /*, [options], callback */) {
         }
     });
 
-    steps.push(function (next) {
+    steps.push((next) => {
 
         // Load plugins
 
-        var plugins = [];
-        var parsed;
+        let plugins = [];
+        let parsed;
 
         if (Array.isArray(manifest.plugins)) {
-            for (var i = 0, l = manifest.plugins.length; i < l; i++) {
-                var pluginObject = manifest.plugins[i];
-                var keys = Object.keys(pluginObject);
+            for (let i = 0; i < manifest.plugins.length; ++i) {
+                const pluginObject = manifest.plugins[i];
+                const keys = Object.keys(pluginObject);
 
                 Hoek.assert(keys.length === 1, 'Invalid plugin config');
 
@@ -97,23 +98,23 @@ exports.compose = function (manifest /*, [options], callback */) {
             }
         }
         else {
-            Object.keys(manifest.plugins || {}).forEach(function (name) {
+            Object.keys(manifest.plugins || {}).forEach((name) => {
 
                 parsed = internals.parsePlugin(name, manifest.plugins[name], options.relativeTo);
                 plugins = plugins.concat(parsed);
             });
         }
 
-        Items.serial(plugins, function (plugin, nextRegister) {
+        Items.serial(plugins, (plugin, nextRegister) => {
 
             server.register(plugin.module, plugin.apply, nextRegister);
         }, next);
     });
 
-    Items.serial(steps, function (step, nextStep) {
+    Items.serial(steps, (step, nextStep) => {
 
         step(nextStep);
-    }, function (err) {
+    }, (err) => {
 
         if (err) {
             return callback(err);
@@ -129,16 +130,16 @@ internals.parseServer = function (server, relativeTo) {
     if (server.cache) {
         server = Hoek.clone(server);
 
-        var caches = [];
-        var config = [].concat(server.cache);
+        const caches = [];
+        const config = [].concat(server.cache);
 
-        for (var i = 0, il = config.length; i < il; ++i) {
-            var item = config[i];
+        for (let i = 0; i < config.length; ++i) {
+            let item = config[i];
             if (typeof item === 'string') {
                 item = { engine: item };
             }
             if (typeof item.engine === 'string') {
-                var strategy = item.engine;
+                let strategy = item.engine;
                 if (relativeTo && strategy[0] === '.') {
                     strategy = Path.join(relativeTo, strategy);
                 }
@@ -158,21 +159,21 @@ internals.parseServer = function (server, relativeTo) {
 
 internals.parsePlugin = function (name, plugin, relativeTo) {
 
-    var path = name;
+    let path = name;
     if (relativeTo && path[0] === '.') {
         path = Path.join(relativeTo, path);
     }
 
     if (Array.isArray(plugin)) {
-        var plugins = [];
+        const plugins = [];
 
         Hoek.assert(plugin.length > 0, 'Invalid plugin configuration');
 
-        plugin.forEach(function (instance) {
+        plugin.forEach((instance) => {
 
             Hoek.assert(typeof instance === 'object', 'Invalid plugin configuration');
 
-            var registerOptions = Hoek.cloneWithShallow(instance, 'options');
+            const registerOptions = Hoek.cloneWithShallow(instance, 'options');
             delete registerOptions.options;
 
             plugins.push({

--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
     "hapi"
   ],
   "engines": {
-    "node": ">=0.10.32"
+    "node": ">=4.0"
   },
   "dependencies": {
-    "boom": "2.x.x",
-    "hapi": "8.x.x || 9.x.x || 10.x.x || 11.x.x",
-    "hoek": "2.x.x",
-    "items": "1.x.x",
-    "joi": "5.x.x || 6.x.x"
+    "boom": "3.x.x",
+    "hapi": "11.x.x",
+    "hoek": "3.x.x",
+    "items": "2.x.x",
+    "joi": "7.x.x"
   },
   "devDependencies": {
-    "catbox-memory": "1.x.x",
-    "code": "1.x.x",
-    "lab": "5.x.x"
+    "catbox-memory": "2.x.x",
+    "code": "2.x.x",
+    "lab": "7.x.x"
   },
   "scripts": {
     "test": "node node_modules/lab/bin/lab -a code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -1,30 +1,31 @@
+'use strict';
 // Load modules
 
-var Code = require('code');
-var Glue = require('..');
-var Lab = require('lab');
+const Code = require('code');
+const Glue = require('..');
+const Lab = require('lab');
 
 
 // Declare internals
 
-var internals = {};
+const internals = {};
 
 
 // Test shortcuts
 
-var lab = exports.lab = Lab.script();
-var describe = lab.describe;
-var it = lab.it;
-var expect = Code.expect;
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
 
 
-describe('compose()', function () {
+describe('compose()', () => {
 
-    it('composes server with an empty manifest', function (done) {
+    it('composes server with an empty manifest', (done) => {
 
-        var manifest = {};
+        const manifest = {};
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             expect(server.connections).length(1);
@@ -32,39 +33,39 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with server.cache as a string', function (done) {
+    it('composes server with server.cache as a string', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: {
                 cache: '../node_modules/catbox-memory'
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('composes server with server.cache as an array', function (done) {
+    it('composes server with server.cache as an array', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: {
                 cache: ['../node_modules/catbox-memory']
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('composes server with server.cache.engine as a string', function (done) {
+    it('composes server with server.cache.engine as a string', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: {
                 cache: {
                     engine: '../node_modules/catbox-memory'
@@ -72,16 +73,16 @@ describe('compose()', function () {
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('composes server with server.cache.engine as a function', function (done) {
+    it('composes server with server.cache.engine as a function', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: {
                 cache: [{
                     engine: require('catbox-memory')
@@ -89,38 +90,38 @@ describe('compose()', function () {
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('composes server with server.cache.engine resolved using options.relativeTo', function (done) {
+    it('composes server with server.cache.engine resolved using options.relativeTo', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: {
                 cache: '../../node_modules/catbox-memory'
             }
         };
 
-        Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, function (err, server) {
+        Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('composes server with connections array having multiple entries', function (done) {
+    it('composes server with connections array having multiple entries', (done) => {
 
-        var manifest = {
+        const manifest = {
             connections: [
                 { labels: 'a' },
                 { labels: 'b' }
             ]
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             expect(server.connections).length(2);
@@ -128,15 +129,15 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with plugins having a plugin with null options', function (done) {
+    it('composes server with plugins having a plugin with null options', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 '../test/plugins/helloworld.js': null
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             expect(server.plugins.helloworld).to.exist();
@@ -145,15 +146,15 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with plugins having a plugin registered with options', function (done) {
+    it('composes server with plugins having a plugin registered with options', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 '../test/plugins/helloworld.js': { who: 'earth' }
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             expect(server.plugins.helloworld).to.exist();
@@ -162,15 +163,15 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with plugins having a plugin with null options and null register options', function (done) {
+    it('composes server with plugins having a plugin with null options and null register options', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 '../test/plugins/helloworld.js': [{}]
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
             expect(server.plugins.helloworld).to.exist();
@@ -179,9 +180,9 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with plugins having a plugin registered with register options', function (done) {
+    it('composes server with plugins having a plugin registered with register options', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 '../test/plugins/route.js': [{
                     routes: { prefix: '/test/' }
@@ -189,10 +190,10 @@ describe('compose()', function () {
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
-            server.inject('/test/plugin', function (response) {
+            server.inject('/test/plugin', (response) => {
 
                 expect(response.statusCode).to.equal(200);
                 done();
@@ -200,9 +201,9 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with plugins having a plugin loaded multiple times', function (done) {
+    it('composes server with plugins having a plugin loaded multiple times', (done) => {
 
-        var manifest = {
+        const manifest = {
             connections: [
                 { labels: 'a' },
                 { labels: 'b' }
@@ -221,13 +222,13 @@ describe('compose()', function () {
             }
         };
 
-        Glue.compose(manifest, function (err, server) {
+        Glue.compose(manifest, (err, server) => {
 
             expect(err).to.not.exist();
-            server.select('a').inject('/a/plugin', function (responseA) {
+            server.select('a').inject('/a/plugin', (responseA) => {
 
                 expect(responseA.statusCode).to.equal(200);
-                server.select('b').inject('/b/plugin', function (responseB) {
+                server.select('b').inject('/b/plugin', (responseB) => {
 
                     expect(responseB.statusCode).to.equal(200);
                     done();
@@ -236,15 +237,15 @@ describe('compose()', function () {
         });
     });
 
-    it('composes server with plugins resolved using options.relativeTo', function (done) {
+    it('composes server with plugins resolved using options.relativeTo', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 './helloworld.js': null
             }
         };
 
-        Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, function (err, server) {
+        Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, (err, server) => {
 
             expect(err).to.not.exist();
             expect(server.plugins.helloworld.hello).to.equal('world');
@@ -252,17 +253,17 @@ describe('compose()', function () {
         });
     });
 
-    describe('Array of plugins', function () {
+    describe('Array of plugins', () => {
 
-        it('composes server with plugins being an array of plugin objects', function (done) {
+        it('composes server with plugins being an array of plugin objects', (done) => {
 
-            var manifest = {
+            const manifest = {
                 plugins: [
                     { '../test/plugins/helloworld.js': null }
                 ]
             };
 
-            Glue.compose(manifest, function (err, server) {
+            Glue.compose(manifest, (err, server) => {
 
                 expect(err).to.not.exist();
                 expect(server.plugins.helloworld).to.exist();
@@ -271,214 +272,215 @@ describe('compose()', function () {
             });
         });
 
-        it('Only accepts plugin objects with 1 key', { timeout: 30000 }, function (done) {
+        it('Only accepts plugin objects with 1 key', { timeout: 30000 }, (done) => {
 
-            var manifest = {
+            const manifest = {
                 plugins: [
                     { 'test': null, 'fail': null }
                 ]
             };
 
-            expect(function () {
+            expect(() => {
 
-                Glue.compose(manifest, function () {});
+                Glue.compose(manifest, () => {
+                });
             }).to.throw('Invalid plugin config');
             done();
         });
     });
 
-    it('composes server with preConnections handler', function (done) {
+    it('composes server with preConnections handler', (done) => {
 
-        var manifest = {};
-        var options = {
+        const manifest = {};
+        const options = {
             preConnections: function (server, callback) {
 
                 callback();
             }
         };
 
-        Glue.compose(manifest, options, function (err, server) {
+        Glue.compose(manifest, options, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('composes server with prePlugins handler', function (done) {
+    it('composes server with prePlugins handler', (done) => {
 
-        var manifest = {};
-        var options = {
+        const manifest = {};
+        const options = {
             prePlugins: function (server, callback) {
 
                 callback();
             }
         };
 
-        Glue.compose(manifest, options, function (err, server) {
+        Glue.compose(manifest, options, (err, server) => {
 
             expect(err).to.not.exist();
             done();
         });
     });
 
-    it('errors on failed pre handler', function (done) {
+    it('errors on failed pre handler', (done) => {
 
-        var manifest = {};
-        var options = {
+        const manifest = {};
+        const options = {
             prePlugins: function (server, callback) {
 
                 callback({ error: 'failed' });
             }
         };
 
-        Glue.compose(manifest, options, function (err, server) {
+        Glue.compose(manifest, options, (err, server) => {
 
             expect(err).to.exist();
             done();
         });
     });
 
-    it('throws on bogus options.realativeTo path (server.cache)', function (done) {
+    it('throws on bogus options.realativeTo path (server.cache)', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: {
                 cache: './catbox-memory'
             }
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, { relativeTo: __dirname + '/badpath' }, function () { });
+            Glue.compose(manifest, { relativeTo: __dirname + '/badpath' }, () => { });
         }).to.throw(/Cannot find module/);
         done();
     });
 
-    it('throws on bogus options.realativeTo path (plugins)', function (done) {
+    it('throws on bogus options.realativeTo path (plugins)', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 './helloworld.js': null
             }
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, { relativeTo: __dirname + '/badpath' }, function () { });
+            Glue.compose(manifest, { relativeTo: __dirname + '/badpath' }, () => { });
         }).to.throw(/Cannot find module/);
         done();
     });
 
-    it('throws on options not an object', function (done) {
+    it('throws on options not an object', (done) => {
 
-        var manifest = {};
+        const manifest = {};
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, 'hello', function () { });
+            Glue.compose(manifest, 'hello', () => { });
         }).to.throw(/Invalid options/);
         done();
     });
 
-    it('throws on callback not a function', function (done) {
+    it('throws on callback not a function', (done) => {
 
-        var manifest = {};
+        const manifest = {};
 
-        expect(function () {
+        expect(() => {
 
             Glue.compose(manifest, 'hello');
         }).to.throw(/Invalid callback/);
         done();
     });
 
-    it('throws on invalid manifest (not an object)', function (done) {
+    it('throws on invalid manifest (not an object)', (done) => {
 
-        var manifest = 'hello';
+        const manifest = 'hello';
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid manifest/);
         done();
     });
 
-    it('throws on invalid manifest (server not an object)', function (done) {
+    it('throws on invalid manifest (server not an object)', (done) => {
 
-        var manifest = {
+        const manifest = {
             server: 'hello'
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid manifest/);
         done();
     });
 
-    it('throws on invalid manifest (connections not an array)', function (done) {
+    it('throws on invalid manifest (connections not an array)', (done) => {
 
-        var manifest = {
+        const manifest = {
             connections: 'hello'
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid manifest/);
         done();
     });
 
-    it('throws on invalid manifest (connections must have at least one entry)', function (done) {
+    it('throws on invalid manifest (connections must have at least one entry)', (done) => {
 
-        var manifest = {
+        const manifest = {
             connections: []
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid manifest/);
         done();
     });
 
-    it('throws on invalid manifest (plugins not an object)', function (done) {
+    it('throws on invalid manifest (plugins not an object)', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: 'hello'
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid manifest/);
         done();
     });
 
-    it('throws on invalid plugin configuration (empty instances)', function (done) {
+    it('throws on invalid plugin configuration (empty instances)', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 '../test/plugins/helloworld.js': []
             }
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid plugin configuration/);
         done();
     });
 
-    it('throws on invalid plugin configuration (bogus instance)', function (done) {
+    it('throws on invalid plugin configuration (bogus instance)', (done) => {
 
-        var manifest = {
+        const manifest = {
             plugins: {
                 '../test/plugins/helloworld.js': ['bogus']
             }
         };
 
-        expect(function () {
+        expect(() => {
 
-            Glue.compose(manifest, function () { });
+            Glue.compose(manifest, () => { });
         }).to.throw(/Invalid plugin configuration/);
         done();
     });

--- a/test/plugins/helloworld.js
+++ b/test/plugins/helloworld.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.register = function (server, options, next) {
 
     server.expose('hello', options.who || 'world');

--- a/test/plugins/route.js
+++ b/test/plugins/route.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.register = function (server, options, next) {
 
     server.route({


### PR DESCRIPTION
Related to #41 

## Depedencies

* Boom 2 -> 3
* Hoek 2 -> 3
* Items 1 -> 2
* Joi 5 || 6 -> 5 || 6 || 7
* Code 1 -> 2
* Lab 5 -> 7
* Catbox-memory 1 -> 2

## Style

Build is passing with Lab 7.x.x and Eslint activated.

## Engine

Node < 4.0 will not be supported anymore.

-------------------------------

It is my first Hapi contribution, I hope I did not make any mistake :innocent: 