### PR TITLE
Don't force object for plugin options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ internals.schema = {
         registrations: Joi.array().items(Joi.object({
             plugin: [
                 Joi.string(),
-                Joi.object({ register: Joi.string(), options: Joi.object().optional() })
+                Joi.object({ register: Joi.string(), options: Joi.any().optional() })
             ],
             options: Joi.object()
         }))


### PR DESCRIPTION
Hapi doesn't force 'Object' for plugin options. Sometimes I use `String` and it is perfectly valid.