### PR TITLE
Make hapi a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
   },
   "dependencies": {
     "boom": "3.x.x",
-    "hapi": "11.x.x || 12.x.x",
     "hoek": "3.x.x",
     "items": "2.x.x",
     "joi": "7.x.x"
   },
+  "peerDependencies": {
+    "hapi": ">=11.0.0 <13"
+  },
   "devDependencies": {
     "catbox-memory": "2.x.x",
     "code": "2.x.x",
+    "hapi": "12.x.x",
     "lab": "8.x.x"
   },
   "scripts": {


### PR DESCRIPTION
Moving hapi to peer dependencies and supporting versions 11 and 12.
Using v12 for development.