### PR TITLE
add plugin-specific registration options to schema

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,19 @@ internals.schema = {
         registrations: Joi.array().items(Joi.object({
             plugin: [
                 Joi.string(),
-                Joi.object({ register: Joi.string(), options: Joi.any().optional() })
+                Joi.object({
+                    register: Joi.string(),
+                    options: Joi.any().optional(),
+                    once: Joi.boolean().optional(),
+                    routes: Joi.object({
+                        prefix: Joi.string().regex(/^\/.+/),
+                        vhost: Joi.alternatives([
+                            Joi.string().hostname(),
+                            Joi.array().items(Joi.string().hostname()).min(1)
+                        ])
+                    }).optional(),
+                    select: Joi.array().items(Joi.string()).single().optional()
+                })
             ],
             options: Joi.object()
         }))


### PR DESCRIPTION
# Background 

Glue allows users to specify which plugins to be loaded via the `registrations` property. Glue enforces the schema for each registration provided.

# Problem
Glue's registration schema does not allow for `select`, `once`, or `routes` to be added at a plugin-specific level. These options are supported and [documented by Hapi](http://hapijs.com/api#serverregisterplugins-options-callback).

# Solution
Borrow [Hapi's schema](https://github.com/hapijs/hapi/blob/4e78875d30a458d835520a8614e2e43f2137f1e1/lib/schema.js#L306) for the aforementioned options and add it to Glue's schema. 

# Discussion

As Hapi's options change, do we want to have to keep Glue's Joi schemas up to date? Perhaps we could remove validation from Glue altogether and let Hapi handle it?