### PR TITLE
Adding support for ES2015 Babel transpiled modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -183,5 +183,9 @@ internals.parsePlugin = function (plugin, relativeTo) {
     }
 
     plugin.register = require(path);
+    if (plugin.register.__esModule) {
+        plugin.register = plugin.register.default;
+    }
+
     return plugin;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -401,6 +401,24 @@ describe('compose()', () => {
                 done();
             });
         });
+
+        it('has a registration with a ES2015 transpiled plugin', (done) => {
+
+            const manifest = {
+                registrations: [
+                    {
+                        plugin: './es2015.js'
+                    }
+                ]
+            };
+
+            Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, (err, server) => {
+
+                expect(err).to.not.exist();
+                expect(server.plugins.es2015.loaded).to.equal(true);
+                done();
+            });
+        });
     });
 
     it('composes a server with a preConnections handler', (done) => {

--- a/test/plugins/es2015.js
+++ b/test/plugins/es2015.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+    value: true
+});
+const register = function (server, options, next) {
+
+    server.expose('loaded', true);
+    next();
+};
+
+register.attributes = {
+    name: 'es2015',
+    multiple: false
+};
+
+exports.default = {
+    register: register
+};


### PR DESCRIPTION
When Babel transpile `export default` it adds a `__esModule` property to the module when requiring it in the code. So this change is to check this property and then loads the register from `default` property created by Babel