### PR TITLE
allow plugin options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ internals.schema = {
         registrations: Joi.array().items(Joi.object({
             plugin: [
                 Joi.string(),
-                Joi.object({ register: Joi.string(), options: Joi.object() }).unknown()
+                Joi.object({ register: Joi.string() }).unknown()
             ],
             options: Joi.object()
         }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ internals.schema = {
         registrations: Joi.array().items(Joi.object({
             plugin: [
                 Joi.string(),
-                Joi.object({ register: Joi.string() }).unknown()
+                Joi.object({ register: Joi.string(), options: Joi.object() }).unknown()
             ],
             options: Joi.object()
         }))
@@ -172,7 +172,6 @@ internals.parseServer = function (server, relativeTo) {
 
 internals.parsePlugin = function (plugin, relativeTo) {
 
-    plugin = Hoek.cloneWithShallow(plugin, ['options']);
     if (typeof plugin === 'string') {
         plugin = { register: plugin };
     }


### PR DESCRIPTION
This fixes my issue here: https://github.com/hapijs/glue/issues/75

I use it like this:
```
{
    registrations: [
        {
            plugin: {
                register: 'k7',
                options: { // server.register({register, OPTIONS}, options)
                    {
                        connectionString: 'mongodb://localhost:27017/xxx',
                        adapter: MongooseK7,
                        models: 'models/*.js'
                    }
                }
            },
            options: { // server.register(plugin, OPTIONS)
                routes: {
                    prefix: '/v1'
                }
            }
        }
    ]
}
```