### PR TITLE
Refactors Joi.array() to utilize .items()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ internals.schema = {
     }),
     manifest: Joi.object({
         server: Joi.object(),
-        connections: Joi.array(Joi.object()),
+        connections: Joi.array().items(Joi.object()),
         registrations: Joi.array().items(Joi.object({
             plugin: [
                 Joi.string(),

--- a/test/index.js
+++ b/test/index.js
@@ -619,6 +619,21 @@ describe('compose()', () => {
         done();
     });
 
+    it('throws on invalid manifest (connections array items not objects)', (done) => {
+
+        const manifest = {
+            connections: [
+                'hello'
+            ]
+        };
+
+        expect(() => {
+
+            Glue.compose(manifest, () => { });
+        }).to.throw(/Invalid manifest/);
+        done();
+    });
+
     it('throws on invalid manifest (registrations not an array)', (done) => {
 
         const manifest = {


### PR DESCRIPTION
`Joi.array(Joi.object())` does not have any functionality, but does throw an error beginning in Joi [v10.0.3](https://github.com/hapijs/joi/pull/1054).

This PR refactors to utilize `Joi.array().items(Joi.object())` to allow for the upgrade to Joi v10.0.3+ and Hapi v16.x

Closes #83 