### PR TITLE
Hapi v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Glue can support different versions of hapi. Adding support for a new version of
 
 By default NPM will resolve Glue's dependency on hapi using the most recent supported version of hapi. To force a specific supported hapi version for your project, include hapi in your package dependencies along side of Glue.
 
-Glue currently supports hapi **11**, **12**, **13**, **14** and **15**.
+Glue currently supports hapi **11**, **12**, **13**, **14**, **15**, and **16**.

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "node": ">=4.0"
   },
   "dependencies": {
-    "hapi": "11.x.x || 12.x.x || 13.x.x || 14.x.x || 15.x.x",
+    "hapi": "11.x.x || 12.x.x || 13.x.x || 14.x.x || 15.x.x || 16.x.x",
     "hoek": "4.x.x",
     "items": "2.x.x",
-    "joi": "9.x.x"
+    "joi": "10.x.x"
   },
   "devDependencies": {
     "catbox-memory": "2.x.x",


### PR DESCRIPTION
This PR adds support for Hapi v16.x and Joi v10.x . 
Please note that this is dependent upon #84 due to invalid `Joi.array(Joi.object())` syntax.

Closes #82 