### PR TITLE
Added function support on plugins registration

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ Composes a hapi server object where:
     + If `server.cache` is specified, Glue will parse the entry and replace any prototype function field (eg. `engine`) specified as string by calling `require()` with that string.
   * `connections` - an array of connection options objects that are mapped to calls of [server.connection([options])](http://hapijs.com/api#serverconnectionoptions)
   * `registrations` - an array of objects holding entries to register with [server.register(plugin, [options], callback)](http://hapijs.com/api#serverregisterplugins-options-callback).  Each object has two fields that map directly to the `server.register` named parameters:
-    + `plugin` - Glue will parse the entry and replace any plugin function field specified as a string by calling `require()` with that string. The array form of this parameter accepted by `server.register()` is not allowed; use multiple registration objects instead.
+    + `plugin` - Glue will parse the entry and replace any plugin function field specified as a string by calling `require()` with that string or just put a plugin function to register it. The array form of this parameter accepted by `server.register()` is not allowed; use multiple registration objects instead.
     + `options` - optional option object passed to `server.register()`.
 + `options` - an object having
   * `relativeTo` - a file-system path string that is used to resolve loading modules with `require`.  Used in `server.cache` and `registrations[].plugin`
@@ -80,7 +80,15 @@ const manifest = {
                     prefix: '/admin'
                 }
             }
-        }
+        },
+        {
+            plugin: {
+                register: require('./awesome-plugin.js'),
+                options: {
+                    whyNot: true
+                }
+            }
+        },
     ]
 };
 
@@ -139,9 +147,14 @@ server.register(plugin, registerOptions, (err) => {
             if (err) {
                 throw err;
             }
-            server.start(() => {
-
-                console.log('hapi days!');
+            plugin = require('./awesome-plugin.js');
+            server.register(plugin, {whyNot: true}, (err) => {
+                if (err) {
+                    throw err;
+                }
+                server.start(() => {
+                    console.log('hapi days!');
+                }); 
             });
         });
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ internals.schema = {
         registrations: Joi.array().items(Joi.object({
             plugin: [
                 Joi.string(),
-                Joi.object({ register: Joi.string() }).unknown()
+                Joi.object({ register: [Joi.string(), Joi.func()] }).unknown()
             ],
             options: Joi.object()
         }))
@@ -177,11 +177,15 @@ internals.parsePlugin = function (plugin, relativeTo) {
         plugin = { register: plugin };
     }
 
-    let path = plugin.register;
-    if (relativeTo && path[0] === '.') {
-        path = Path.join(relativeTo, path);
+    if (typeof plugin.register === 'string') {
+        let path = plugin.register;
+
+        if (relativeTo && path[0] === '.') {
+            path = Path.join(relativeTo, path);
+        }
+
+        plugin.register = require(path);
     }
 
-    plugin.register = require(path);
     return plugin;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glue",
   "description": "Server composer for hapi.js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/hapijs/glue"

--- a/test/index.js
+++ b/test/index.js
@@ -273,6 +273,23 @@ describe('compose()', () => {
             });
         });
 
+        it('has a registration with plugin function instead of path to be required', (done) => {
+
+            const manifest = {
+                registrations: [{
+                    plugin: require('./plugins/helloworld')
+                }]
+            };
+
+            Glue.compose(manifest, (err, server) => {
+
+                expect(err).to.not.exist();
+                expect(server.plugins.helloworld).to.exist();
+                expect(server.plugins.helloworld.hello).to.equal('world');
+                done();
+            });
+        });
+
         it('has a registration with no configuration', (done) => {
 
             const manifest = {


### PR DESCRIPTION
Hi I add function support on registrations: [{plugin: require('./my-awesome-plugin.js')}] because some times to use things like server rendering is needed that webpack or something like that parse imports/require it self.
Also let people do it with his own require/import logic.