### PR TITLE
Update to hapi v17.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
+  - "8"

--- a/API.md
+++ b/API.md
@@ -1,31 +1,65 @@
 
 ## Interface
 
-Glue exports a single function `compose` accepting a JSON `manifest` file specifying the hapi server options, connections, and registrations.
+Glue exports a single function `compose` accepting a JSON `manifest` file specifying the hapi server options and plugin registrations and returns a hapi `server` object.
+To start the server use the returned object to call `await server.start()`.
 
-### `compose(manifest, [options], [callback])`
+### `await compose(manifest, [options])`
 
 Composes a hapi server object where:
 + `manifest` - an object having:
   * `server` - an object containing the options passed to [new Hapi.Server([options])](http://hapijs.com/api#new-serveroptions)
     + If `server.cache` is specified, Glue will parse the entry and replace any prototype function field (eg. `engine`) specified as string by calling `require()` with that string.
-  * `connections` - an array of connection options objects that are mapped to calls of [server.connection([options])](http://hapijs.com/api#serverconnectionoptions)
-  * `registrations` - an array of objects holding entries to register with [server.register(plugin, [options], callback)](http://hapijs.com/api#serverregisterplugins-options-callback).  Each object has two fields that map directly to the `server.register` named parameters:
-    + `plugin` - Glue will parse the entry and replace any plugin function field specified as a string by calling `require()` with that string or just put a plugin function to register it. The array form of this parameter accepted by `server.register()` is not allowed; use multiple registration objects instead.
-    + `options` - optional option object passed to `server.register()`.
-+ `options` - an object having
-  * `relativeTo` - a file-system path string that is used to resolve loading modules with `require`.  Used in `server.cache` and `registrations[].plugin`
-  * `preConnections` - a callback function that is called prior to adding connections to the server. The function signature is `function (server, next)` where:
-    + `server` - is the server object returned from `new Server(options)`.
-    + `next`- the callback function the method must call to return control over to glue
-  * `preRegister` - a callback function that is called prior to registering plugins with the server. The function signature is `function (server, next)` where:
-    + `server` - is the server object with all connections selected.
-    + `next`- the callback function the method must call to return control over to glue
-+ `callback` - the callback function with signature `function (err, server)` where:
-  * `err` - the error response if a failure occurred, otherwise `null`.
-  * `server` - the server object. Call `server.start()` to actually start the server.
+  * `register` - an object containing two properties: the `plugins` to be registered and `options` to pass to `server.register`
+    + `plugins` - an array of entries to register with [await server.register(plugins, [options])](http://hapijs.com/api#-await-serverregisterplugins-options).
+      * each entry may be one of three alternatives:
+        1. A string to be `require()`d during composition.
+        ```js
+        {
+          register: {
+            plugins: [ 'myplugin' ]
+          }
+        }
+        ```
+        2. An object containing the `plugin` property which is a string to be `require`d during composition
+        ```js
+        {
+          register: {
+            plugins: [ { plugin: 'myplugin' } ]
+          }
+        }
+        ```
+        3. An object containing the `plugin` property which is the plugin object to be passed directly to `await server.register`*[]:
+        ```js
+        {
+          register: {
+            plugins: [ { plugin: require('myplugin') } ]
+          }
+        }
+        ```
+      * object entries may also contain the `options` property, which contains the plugin-level options passed to the plugin at registration time.
+      ```js
+      {
+        register: {
+          plugins: [ { plugin: 'myplugin', options: { host: 'my-host.com' } } ]
+        }
+      }
+      ```
+      * object entries may also contain override registration-options such as `routes`.
+      ```js
+        {
+          register: {
+            plugins: [ { plugin: 'myplugin', routes: { prefix: '/test/' } } ]
+          }
+        }
+        ```
+    + `options` - optional registration-options object passed to `server.register()`.
++ `options` - an object containing the following `compose` options:
+  * `relativeTo` - a file-system path string that is used to resolve loading modules with `require`.  Used in `server.cache` and `register.plugins[]`
+  * `preRegister` - an async function that is called prior to registering plugins with the server. The function signature is `async function (server)` where:
+    + `server` - is the hapi server object.
 
-If no `callback` is provided, a `Promise` object is returned where the value passed to the Promise resolve handler is the `server` object and the value passed to the Promise reject handler is the error response if a failure occurred.
+`compose` returns the hapi server object. Call `await server.start()` to actually start the server.
 
 ### Notes
 
@@ -40,125 +74,76 @@ const Glue = require('glue');
 
 const manifest = {
     server: {
-        cache: 'redis'
+        cache: 'redis',
+        port: 8000
     },
-    connections: [
-        {
-            port: 8000,
-            labels: ['web']
-        },
-        {
-            port: 8001,
-            labels: ['admin']
-        }
-    ],
-    registrations: [
-        {
-            plugin: {
-                register: './assets',
+    register: {
+        plugins: [
+            './awesome-plugin.js',
+            {
+                plugin: require('myplugin'),
                 options: {
                     uglify: true
                 }
-            }
-        },
-        {
-            plugin: './ui-user',
-            options: {
-                select: ['web']
-            }
-        },
-        {
-            plugin: {
-                register: './ui-admin',
+            },
+            {
+                plugin: './ui-user'
+            },
+            {
+                plugin: './ui-admin',
                 options: {
                     sessiontime: 500
-                }
-            },
-            options: {
-                select: ['admin'],
+                },
                 routes: {
                     prefix: '/admin'
                 }
             }
-        },
-        {
-            plugin: {
-                register: require('./awesome-plugin.js'),
-                options: {
-                    whyNot: true
-                }
-            }
-        },
-    ]
+        ]
+    }
 };
 
 const options = {
     relativeTo: __dirname
 };
 
-Glue.compose(manifest, options, (err, server) => {
-
-    if (err) {
-        throw err;
-    }
-    server.start(() => {
-
-        console.log('hapi days!');
-    });
-});
+try {
+    const server = await Glue.compose(manifest, options);
+    await server.start();
+    console.log('hapi days!');
+}
+catch (err) {
+    console.error(err);
+    process.exit(1);
+}
 ```
 
 The above is translated into the following equivalent hapi API calls.
 
 ```javascript
-'use strict';
+try {
+    const server = Hapi.server({ cache: [{ engine: require('redis') }], port: 8000 });
+    const plugins = [];
+    const registerOptions = {};
+    let pluginPath;
 
-const server = Hapi.Server({ cache: [{ engine: require('redis') }] });
-server.connection({ port: 8000, labels: ['web'] });
-server.connection({ port: 8001, labels: ['admin'] });
-let plugin;
-let pluginPath;
-let pluginOptions;
-let registerOptions;
-pluginPath = Path.join(__dirname, './assets');
-pluginOptions = { uglify: true };
-plugin = { register: require(pluginPath), options: pluginOptions };
-registerOptions = { };
-server.register(plugin, registerOptions, (err) => {
+    pluginPath = Path.join(__dirname, './awesome-plugin.js');
+    plugins.push({ plugin: require(pluginPath) });
 
-    if (err) {
-        throw err;
-    }
+    plugins.push({ plugin: require('myplugin'), options:{ uglify: true } });
+
     pluginPath = Path.join(__dirname, './ui-user');
-    pluginOptions = { };
-    plugin = { register: require(pluginPath), options: pluginOptions };
-    registerOptions = { select: ['web'] };
-    server.register(plugin, registerOptions, (err) => {
+    plugins.push({ plugin: require(pluginPath) });
 
-        if (err) {
-            throw err;
-        }
-        pluginPath = Path.join(__dirname, './ui-admin');
-        pluginOptions = { sessiontime: 500 };
-        plugin = { register: require(pluginPath), options: pluginOptions };
-        registerOptions = { select: ['admin'], routes: { prefix: '/admin' } };
-        server.register(plugin, registerOptions, (err) => {
+    pluginPath = Path.join(__dirname, './ui-admin');
+    plugins.push({ plugin: require(pluginPath), options: { sessiontime: 500 }, routes: { prefix: '/admin' } });
 
-            if (err) {
-                throw err;
-            }
-            plugin = require('./awesome-plugin.js');
-            server.register(plugin, {whyNot: true}, (err) => {
+    await server.register(plugins, registerOptions);
 
-                if (err) {
-                    throw err;
-                }
-                server.start(() => {
-
-                    console.log('hapi days!');
-                });
-            });
-        });
-    });
-});
+    await server.start();
+    console.log('hapi days!');
+}
+catch (err)
+    console.error(err);
+    process.exit(1);
+}
 ```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ Lead Maintainer - [Chris Rempel](https://github.com/csrl)
 
 Glue provides configuration based composition of hapi's Server object. Specifically it wraps
 
- * `server = new Hapi.Server(Options)`
- * one or more `server.connection(Options)`
- * zero or more `server.register(Plugin, Options)`
+ * `server = Hapi.server(Options)`
+ * `server.register(Plugins, Options)`
 
 calling each based on the configuration generated from the Glue manifest.
 
 ### Interface
 
-Glue's [API](API.md) is a single function `compose` accepting a JSON `manifest` file specifying the hapi server options, connections, and registrations.
+Glue's [API](API.md) is a single function `compose` accepting a JSON `manifest` specifying the hapi server options and registrations.
 
 ### hapi version dependency
 
@@ -24,4 +23,5 @@ Glue can support different versions of hapi. Adding support for a new version of
 
 By default NPM will resolve Glue's dependency on hapi using the most recent supported version of hapi. To force a specific supported hapi version for your project, include hapi in your package dependencies along side of Glue.
 
-Glue currently supports hapi **11**, **12**, **13**, **14**, **15**, and **16**.
+Glue version 5 currently only supports hapi **17**.
+For support of hapi **11**, **12**, **13**, **14**, **15**, or **16** please use Glue@4.2.x .

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
 const Path = require('path');
 const Hapi = require('hapi');
 const Hoek = require('hoek');
-const Items = require('items');
 const Joi = require('joi');
 
 
@@ -21,130 +20,46 @@ internals.schema = {
     }),
     manifest: Joi.object({
         server: Joi.object(),
-        connections: Joi.array().items(Joi.object()),
-        registrations: Joi.array().items(Joi.object({
-            plugin: [
-                Joi.string(),
-                Joi.object({ register: [Joi.string(), Joi.func()] }).unknown()
-            ],
-            options: Joi.object()
-        }))
+        register: Joi.object({
+            plugins: Joi.array(),
+            options: Joi.any()
+        })
     })
 };
 
 
-exports.compose = function (manifest /*, [options], [callback] */) {
-
-    Hoek.assert(arguments.length <= 3, 'Invalid number of arguments');
-
-    const options = arguments.length === 1 || typeof arguments[1] === 'function' ? {} : arguments[1];
-    const callback = typeof arguments[arguments.length - 1] === 'function' ? arguments[arguments.length - 1] : null;
-
-    // Return Promise if no callback provided
-
-    if (!callback) {
-        return new Promise((resolve, reject) => {
-
-            exports.compose(manifest, options, (err, server) => {
-
-                if (err) {
-                    return reject(err);
-                }
-
-                return resolve(server);
-            });
-        });
-    }
+exports.compose = async function (manifest, options = {}) {
 
     Joi.assert(options, internals.schema.options, 'Invalid options');
     Joi.assert(manifest, internals.schema.manifest, 'Invalid manifest');
 
-    // Create server
-
     const serverOpts = internals.parseServer(manifest.server || {}, options.relativeTo);
-    const server = new Hapi.Server(serverOpts);
+    const server = Hapi.server(serverOpts);
 
-    const steps = [];
-    steps.push((next) => {
+    if (options.preRegister) {
+        await options.preRegister(server);
+    }
 
-        if (options.preConnections) {
-            options.preConnections(server, next);
-        }
-        else {
-            next();
-        }
-    });
+    if (manifest.register && manifest.register.plugins) {
+        const plugins = manifest.register.plugins.map((plugin) => {
 
-    steps.push((next) => {
+            return internals.parsePlugin(plugin, options.relativeTo);
+        });
 
-        // Load connections
+        await server.register(plugins, manifest.register.options || {});
+    }
 
-        if (manifest.connections && manifest.connections.length > 0) {
-            manifest.connections.forEach((connection) => {
-
-                server.connection(connection);
-            });
-        }
-        else {
-            server.connection();
-        }
-
-        next();
-    });
-
-    steps.push((next) => {
-
-        if (options.preRegister) {
-            options.preRegister(server, next);
-        }
-        else {
-            next();
-        }
-    });
-
-    steps.push((next) => {
-
-        // Load registrations
-
-        if (manifest.registrations) {
-            const registrations = manifest.registrations.map((reg) => {
-
-                return {
-                    plugin: internals.parsePlugin(reg.plugin, options.relativeTo),
-                    options: reg.options || {}
-                };
-            });
-            Items.serial(registrations, (reg, nextRegister) => {
-
-                server.register(reg.plugin, reg.options, nextRegister);
-            }, next);
-        }
-        else {
-            next();
-        }
-    });
-
-    Items.serial(steps, (step, nextStep) => {
-
-        step(nextStep);
-    }, (err) => {
-
-        if (err) {
-            return Hoek.nextTick(callback)(err);
-        }
-
-        Hoek.nextTick(callback)(null, server);
-    });
+    return server;
 };
 
 
-internals.parseServer = function (server, relativeTo) {
+internals.parseServer = function (serverOpts, relativeTo) {
 
-    if (server.cache) {
-        server = Hoek.clone(server);
+    if (serverOpts.cache) {
+        serverOpts = Hoek.clone(serverOpts);
 
         const caches = [];
-        const config = [].concat(server.cache);
+        const config = [].concat(serverOpts.cache);
         for (let i = 0; i < config.length; ++i) {
             let item = config[i];
             if (typeof item === 'string') {
@@ -163,28 +78,33 @@ internals.parseServer = function (server, relativeTo) {
             caches.push(item);
         }
 
-        server.cache = caches;
+        serverOpts.cache = caches;
     }
 
-    return server;
+    return serverOpts;
 };
-
 
 internals.parsePlugin = function (plugin, relativeTo) {
 
-    plugin = Hoek.cloneWithShallow(plugin, ['options']);
     if (typeof plugin === 'string') {
-        plugin = { register: plugin };
+        return internals.requireRelativeTo(plugin, relativeTo);
     }
 
-    if (typeof plugin.register === 'string') {
-        let path = plugin.register;
-        if (relativeTo && path[0] === '.') {
-            path = Path.join(relativeTo, path);
-        }
+    if (typeof plugin.plugin === 'string') {
+        const pluginObject = Hoek.cloneWithShallow(plugin, ['options']);
+        pluginObject.plugin = internals.requireRelativeTo(plugin.plugin, relativeTo);
 
-        plugin.register = require(path);
+        return pluginObject;
     }
 
     return plugin;
+};
+
+internals.requireRelativeTo = function (path, relativeTo) {
+
+    if (relativeTo && path[0] === '.') {
+        path = Path.join(relativeTo, path);
+    }
+
+    return require(path);
 };

--- a/package.json
+++ b/package.json
@@ -15,18 +15,17 @@
     "hapi"
   ],
   "engines": {
-    "node": ">=4.0"
+    "node": ">=8.0"
   },
   "dependencies": {
-    "hapi": "11.x.x || 12.x.x || 13.x.x || 14.x.x || 15.x.x || 16.x.x",
-    "hoek": "4.x.x",
-    "items": "2.x.x",
-    "joi": "10.x.x"
+    "hapi": "17.x.x",
+    "hoek": "5.x.x",
+    "joi": "13.x.x"
   },
   "devDependencies": {
     "catbox-memory": "2.x.x",
-    "code": "4.x.x",
-    "lab": "14.x.x"
+    "code": "5.x.x",
+    "lab": "15.x.x"
   },
   "scripts": {
     "test": "node node_modules/lab/bin/lab -a code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,6 @@
 'use strict';
 // Load modules
 
-const Code = require('code');
 const Glue = require('..');
 const Lab = require('lab');
 const Hoek = require('hoek');
@@ -14,99 +13,30 @@ const internals = {};
 
 // Test shortcuts
 
-const lab = exports.lab = Lab.script();
-const describe = lab.describe;
-const it = lab.it;
-const expect = Code.expect;
-
+const { describe, expect, it } = exports.lab = Lab.script();
 
 describe('compose()', () => {
 
-    it('composes a server with an empty manifest', (done) => {
+    it('composes a server with an empty manifest', async () => {
 
         const manifest = {};
-
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            expect(server.connections).length(1);
-            done();
-        });
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
     });
 
-    it('ensures compose callback is called async', (done) => {
-
-        const manifest = {};
-        let async = true;
-
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            async = false;
-        });
-        expect(async).to.be.true();
-        done();
-    });
-
-    it('returns a promise if no options and no callback is provided', (done) => {
-
-        const manifest = {};
-
-        Glue.compose(manifest).then((server) => {
-
-            expect(server.connections).length(1);
-            done();
-        });
-    });
-
-    it('returns a promise if no callback is provided', (done) => {
-
-        const manifest = {};
-        const options = {};
-
-        Glue.compose(manifest, options).then((server) => {
-
-            expect(server.connections).length(1);
-            done();
-        });
-    });
-
-    it('rejects a promise if an error is thrown', (done) => {
+    it('throws an error', async () => {
 
         const manifest = {
-            registrations: [
-                {
-                    plugin: './invalid-plugin'
-                }
-            ]
-        };
-
-        Glue.compose(manifest).catch((err) => {
-
-            expect(err).to.exist();
-            expect(err.code).to.equal('MODULE_NOT_FOUND');
-            done();
-        });
-    });
-
-    it('rejects a promise if an error is returned', (done) => {
-
-        const manifest = {};
-        const options = {
-            preRegister: function (server, callback) {
-
-                callback({ error: 'failed' });
+            register: {
+                plugins: ['invalidplugin']
             }
         };
 
-        Glue.compose(manifest, options).then(null, (err) => {
-
-            expect(err).to.exist();
-            done();
-        });
+        await expect(Glue.compose(manifest)).to.reject(Error, /Cannot find module/);
     });
 
-    it('composes a server with server.cache as a string', (done) => {
+    it('composes a server with server.cache as a string', async () => {
 
         const manifest = {
             server: {
@@ -114,14 +44,12 @@ describe('compose()', () => {
             }
         };
 
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache as an array', (done) => {
+    it('composes a server with server.cache as an array', async () => {
 
         const manifest = {
             server: {
@@ -129,14 +57,12 @@ describe('compose()', () => {
             }
         };
 
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine as a string', (done) => {
+    it('composes a server with server.cache.engine as a string', async () => {
 
         const manifest = {
             server: {
@@ -146,14 +72,12 @@ describe('compose()', () => {
             }
         };
 
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine as a function', (done) => {
+    it('composes a server with server.cache.engine as a function', async () => {
 
         const manifest = {
             server: {
@@ -163,14 +87,12 @@ describe('compose()', () => {
             }
         };
 
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine resolved using options.relativeTo', (done) => {
+    it('composes a server with server.cache.engine resolved using options.relativeTo', async () => {
 
         const manifest = {
             server: {
@@ -178,368 +100,246 @@ describe('compose()', () => {
             }
         };
 
-        Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
+        const server = await Glue.compose(manifest, { relativeTo: __dirname + '/plugins' });
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server without modifying the manifest', (done) => {
+    it('composes a server without modifying the manifest', async () => {
 
         const manifest = {
-            registrations: [
-                {
-                    plugin: {
-                        register: '../test/plugins/helloworld.js'
-                    }
-                }
-            ]
-        };
-        const clone = Hoek.clone(manifest);
-
-        Glue.compose(manifest, (err, server) => {
-
-            expect(err).to.not.exist();
-            expect(server.plugins.helloworld).to.exist();
-            expect(Hoek.deepEqual(manifest, clone)).to.equal(true);
-            done();
-        });
-    });
-
-    describe('composes a server\'s connections', () => {
-
-        it('has no entries', (done) => {
-
-            const manifest = {
-                connections: []
-            };
-
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.connections).length(1);
-                done();
-            });
-        });
-
-        it('has a single entry', (done) => {
-
-            const manifest = {
-                connections: [
-                    { labels: 'a' }
-                ]
-            };
-
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.connections).length(1);
-                done();
-            });
-        });
-
-        it('has multiple entries', (done) => {
-
-            const manifest = {
-                connections: [
-                    { labels: 'a' },
-                    { labels: 'b' }
-                ]
-            };
-
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.connections).length(2);
-                done();
-            });
-        });
-    });
-
-    describe('composes a server\'s registrations', () => {
-
-        it('has no registrations', (done) => {
-
-            const manifest = {
-                registrations: []
-            };
-
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins).length(0);
-                done();
-            });
-        });
-
-        it('has a registration with plugin function instead of path to be required', (done) => {
-
-            const manifest = {
-                registrations: [{
-                    plugin: require('./plugins/helloworld')
-                }]
-            };
-
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld).to.exist();
-                expect(server.plugins.helloworld.hello).to.equal('world');
-                done();
-            });
-        });
-
-        it('has a registration with no configuration', (done) => {
-
-            const manifest = {
-                registrations: [
+            register: {
+                plugins: [
                     {
                         plugin: '../test/plugins/helloworld.js'
                     }
                 ]
-            };
+            }
+        };
+        const clone = Hoek.clone(manifest);
 
-            Glue.compose(manifest, (err, server) => {
+        const server = await Glue.compose(manifest);
+        expect(server.plugins.helloworld).to.exist();
+        expect(Hoek.deepEqual(manifest, clone)).to.equal(true);
+    });
 
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld).to.exist();
-                expect(server.plugins.helloworld.hello).to.equal('world');
-                done();
-            });
-        });
+    describe('composes a server\'s registrations', () => {
 
-        it('passes through unknown plugin object fields', (done) => {
+        it('has no registrations', async () => {
 
             const manifest = {
-                registrations: [
-                    {
-                        plugin: {
-                            register: '../test/plugins/helloworld.js',
-                            anything: 'whatever'
+                register: {
+                    plugins: []
+                }
+            };
+
+            const server = await Glue.compose(manifest);
+            expect(server.plugins).length(0);
+        });
+
+        it('has a registration with a plugin path only', async () => {
+
+            const manifest = {
+                register: {
+                    plugins: ['../test/plugins/helloworld.js']
+                }
+            };
+
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello).to.equal('world');
+        });
+
+        it('has a registration with plugin function instead of path to be required', async () => {
+
+            const manifest = {
+                register: {
+                    plugins: [{
+                        plugin: require('./plugins/helloworld')
+                    }]
+                }
+            };
+
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello).to.equal('world');
+        });
+
+        it('has a registration with no configuration', async () => {
+
+            const manifest = {
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/helloworld.js'
                         }
-                    }
-                ]
+                    ]
+                }
             };
 
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld).to.exist();
-                expect(server.plugins.helloworld.hello).to.equal('world');
-                done();
-            });
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello).to.equal('world');
         });
 
-        it('passes through original plugin options', (done) => {
+        it('passes through original plugin options', async () => {
 
             const manifest = {
-                registrations: [
-                    {
-                        plugin: {
-                            register: '../test/plugins/helloworld.js',
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/helloworld.js',
                             options: {
                                 who: { i: 'am not a clone' }
                             }
                         }
-                    }
-                ]
+                    ]
+                }
             };
 
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld).to.exist();
-                expect(server.plugins.helloworld.hello === manifest.registrations[0].plugin.options.who).to.be.equal(true);
-                done();
-            });
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello === manifest.register.plugins[0].options.who).to.be.equal(true);
         });
 
-        it('has a registration with no plugin options and no register options', (done) => {
+        it('has a registration with no plugin options and no register options', async () => {
 
             const manifest = {
-                registrations: [
-                    {
-                        plugin: {
-                            register: '../test/plugins/helloworld.js'
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/helloworld.js'
                         }
-                    }
-                ]
+                    ]
+                }
             };
 
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld).to.exist();
-                expect(server.plugins.helloworld.hello).to.equal('world');
-                done();
-            });
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello).to.equal('world');
         });
 
-        it('has a registration with plugin options and no register options', (done) => {
+        it('has a registration with plugin options and no register options', async () => {
 
             const manifest = {
-                registrations: [
-                    {
-                        plugin: {
-                            register: '../test/plugins/helloworld.js',
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/helloworld.js',
                             options: { who: 'earth' }
                         }
-                    }
-                ]
+                    ]
+                }
             };
 
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld).to.exist();
-                expect(server.plugins.helloworld.hello).to.equal('earth');
-                done();
-            });
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld).to.exist();
+            expect(server.plugins.helloworld.hello).to.equal('earth');
         });
 
-        it('has a registration with register options and no plugin options', (done) => {
+        it('has a registration with register options and no plugin options', async () => {
 
             const manifest = {
-                registrations: [
-                    {
-                        plugin: '../test/plugins/route.js',
-                        options: {
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/route.js'
+                        }
+                    ],
+                    options: {
+                        routes: { prefix: '/test/' }
+                    }
+                }
+            };
+
+            const server = await Glue.compose(manifest);
+            const response = await server.inject('/test/plugin');
+            expect(response.statusCode).to.equal(200);
+        });
+
+        it('has a registration with register options in the plugin', async () => {
+
+            const manifest = {
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/route.js',
                             routes: { prefix: '/test/' }
                         }
-                    }
-                ]
+                    ]
+                }
             };
 
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                server.inject('/test/plugin', (response) => {
-
-                    expect(response.statusCode).to.equal(200);
-                    done();
-                });
-            });
+            const server = await Glue.compose(manifest);
+            const response = await server.inject('/test/plugin');
+            expect(response.statusCode).to.equal(200);
         });
 
-        it('has a registration with register options in the plugin', (done) => {
+        it('has a registration with the plugin resolved using options.relativeTo', async () => {
 
             const manifest = {
-                registrations: [
-                    {
-                        plugin: {
-                            register: '../test/plugins/route.js',
+                register: {
+                    plugins: [
+                        {
+                            plugin: './helloworld.js'
+                        }
+                    ]
+                }
+            };
+
+            const server = await Glue.compose(manifest, { relativeTo: __dirname + '/plugins' });
+            expect(server.plugins.helloworld.hello).to.equal('world');
+        });
+
+        it('has a registration with different plugin syntax, some plugin options, main registration options, and plugin-level registration options', async () => {
+
+            const manifest = {
+                register: {
+                    plugins: [
+                        '../test/plugins/helloworld.js',
+                        {
+                            plugin : '../test/plugins/second.js',
+                            options: {
+                                value: 'second'
+                            }
+                        },
+                        {
+                            plugin: require('./plugins/route'),
                             routes: { prefix: '/test/' }
                         }
+                    ],
+                    options: {
+                        routes: { prefix: '/override/me/' }
                     }
-                ]
+                }
             };
 
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                server.inject('/test/plugin', (response) => {
-
-                    expect(response.statusCode).to.equal(200);
-                    done();
-                });
-            });
-        });
-
-        it('has registrations having the same plugin loaded multiple times', (done) => {
-
-            const manifest = {
-                connections: [
-                    { labels: 'a' },
-                    { labels: 'b' }
-                ],
-                registrations: [
-                    {
-                        plugin: '../test/plugins/route.js',
-                        options: {
-                            select: 'a',
-                            routes: { prefix: '/a/' }
-                        }
-                    },
-                    {
-                        plugin: '../test/plugins/route.js',
-                        options: {
-                            select: 'b',
-                            routes: { prefix: '/b/' }
-                        }
-                    }
-                ]
-            };
-
-            Glue.compose(manifest, (err, server) => {
-
-                expect(err).to.not.exist();
-                server.select('a').inject('/a/plugin', (responseA) => {
-
-                    expect(responseA.statusCode).to.equal(200);
-                    server.select('b').inject('/b/plugin', (responseB) => {
-
-                        expect(responseB.statusCode).to.equal(200);
-                        done();
-                    });
-                });
-            });
-        });
-
-        it('has a registration with the plugin resolved using options.relativeTo', (done) => {
-
-            const manifest = {
-                registrations: [
-                    {
-                        plugin: './helloworld.js'
-                    }
-                ]
-            };
-
-            Glue.compose(manifest, { relativeTo: __dirname + '/plugins' }, (err, server) => {
-
-                expect(err).to.not.exist();
-                expect(server.plugins.helloworld.hello).to.equal('world');
-                done();
-            });
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.helloworld.hello).to.equal('world');
+            const response = await server.inject('/test/plugin');
+            expect(response.statusCode).to.equal(200);
+            const secondResponse = await server.inject('/override/me/second');
+            expect(secondResponse.statusCode).to.equal(200);
+            expect(secondResponse.payload).to.equal('second');
         });
     });
 
-    it('composes a server with a preConnections handler', (done) => {
+    it('composes a server with a preRegister handler', async () => {
 
+        let count = 0;
         const manifest = {};
         const options = {
-            preConnections: function (server, callback) {
+            preRegister: function (server) {
 
-                callback();
+                ++count;
             }
         };
 
-        Glue.compose(manifest, options, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
+        await Glue.compose(manifest, options);
+        expect(count).to.equal(1);
     });
 
-    it('composes a server with a preRegister handler', (done) => {
-
-        const manifest = {};
-        const options = {
-            preRegister: function (server, callback) {
-
-                callback();
-            }
-        };
-
-        Glue.compose(manifest, options, (err, server) => {
-
-            expect(err).to.not.exist();
-            done();
-        });
-    });
-
-    it('errors on failed pre handler', (done) => {
+    it('errors on failed pre handler', async () => {
 
         const manifest = {};
         const options = {
@@ -549,14 +349,10 @@ describe('compose()', () => {
             }
         };
 
-        Glue.compose(manifest, options, (err, server) => {
-
-            expect(err).to.exist();
-            done();
-        });
+        await expect(Glue.compose(manifest, options)).to.reject();
     });
 
-    it('throws on bogus options.realativeTo path (server.cache)', (done) => {
+    it('throws on bogus options.relativeTo path (server.cache)', async () => {
 
         const manifest = {
             server: {
@@ -564,103 +360,64 @@ describe('compose()', () => {
             }
         };
 
-        expect(() => {
-
-            Glue.compose(manifest, { relativeTo: __dirname + '/badpath' }, () => { });
-        }).to.throw(/Cannot find module/);
-        done();
+        await expect(Glue.compose(manifest, { relativeTo: __dirname + '/badpath' })).to.reject(Error, /Cannot find module/);
     });
 
-    it('throws on bogus options.realativeTo path (plugins)', (done) => {
+    it('throws on bogus options.relativeTo path (plugins)', async () => {
 
         const manifest = {
-            registrations: [
-                {
-                    plugin: './helloworld.js'
-                }
-            ]
+            register: {
+                plugins: [
+                    {
+                        plugin: './helloworld.js'
+                    }
+                ]
+            }
         };
 
-        expect(() => {
-
-            Glue.compose(manifest, { relativeTo: __dirname + '/badpath' }, () => { });
-        }).to.throw(/Cannot find module/);
-        done();
+        await expect(Glue.compose(manifest, { relativeTo: __dirname + '/badpath' })).to.reject(Error, /Cannot find module/);
     });
 
-    it('throws on options not an object', (done) => {
+    it('throws on options not an object', async () => {
 
         const manifest = {};
 
-        expect(() => {
-
-            Glue.compose(manifest, 'hello', () => { });
-        }).to.throw(/Invalid options/);
-        done();
+        await expect(Glue.compose(manifest, 'hello')).to.reject(Error, /Invalid options/);
     });
 
-    it('throws on invalid manifest (not an object)', (done) => {
+    it('throws on invalid manifest (not an object)', async () => {
 
         const manifest = 'hello';
 
-        expect(() => {
-
-            Glue.compose(manifest, () => { });
-        }).to.throw(/Invalid manifest/);
-        done();
+        await expect(Glue.compose(manifest)).to.reject(Error, /Invalid manifest/);
     });
 
-    it('throws on invalid manifest (server not an object)', (done) => {
+    it('throws on invalid manifest (server not an object)', async () => {
 
         const manifest = {
             server: 'hello'
         };
 
-        expect(() => {
-
-            Glue.compose(manifest, () => { });
-        }).to.throw(/Invalid manifest/);
-        done();
+        await expect(Glue.compose(manifest)).to.reject(Error, /Invalid manifest/);
     });
 
-    it('throws on invalid manifest (connections not an array)', (done) => {
-
-        const manifest = {
-            connections: 'hello'
-        };
-
-        expect(() => {
-
-            Glue.compose(manifest, () => { });
-        }).to.throw(/Invalid manifest/);
-        done();
-    });
-
-    it('throws on invalid manifest (connections array items not objects)', (done) => {
+    it('throws on invalid manifest (connections present)', async () => {
 
         const manifest = {
             connections: [
-                'hello'
+                {}
             ]
         };
 
-        expect(() => {
-
-            Glue.compose(manifest, () => { });
-        }).to.throw(/Invalid manifest/);
-        done();
+        await expect(Glue.compose(manifest)).to.reject(Error, /Invalid manifest/);
     });
 
-    it('throws on invalid manifest (registrations not an array)', (done) => {
+    it('throws on invalid manifest (register not an object)', async () => {
 
         const manifest = {
-            registrations: 'hello'
+            register: 'hello'
         };
 
-        expect(() => {
-
-            Glue.compose(manifest, () => { });
-        }).to.throw(/Invalid manifest/);
-        done();
+        await expect(Glue.compose(manifest)).to.reject(Error, /Invalid manifest/);
     });
 });

--- a/test/plugins/helloworld.js
+++ b/test/plugins/helloworld.js
@@ -1,12 +1,9 @@
 'use strict';
 
-exports.register = function (server, options, next) {
+exports.register = function (server, options) {
 
     server.expose('hello', options.who || 'world');
-    next();
 };
 
-exports.register.attributes = {
-    name: 'helloworld',
-    multiple: false
-};
+exports.name = 'helloworld';
+exports.multiple = false;

--- a/test/plugins/second.js
+++ b/test/plugins/second.js
@@ -4,13 +4,13 @@ exports.register = function (server, options) {
 
     server.route({
         method: 'GET',
-        path: 'plugin',
+        path: 'second',
         handler: function (request, h) {
 
-            return 'ok';
+            return options.value || 'ok';
         }
     });
 };
 
-exports.name = 'route';
+exports.name = 'second';
 exports.multiple = true;


### PR DESCRIPTION
Updates to hapi v17 and lab v15

Breaking Changes:
  - Remove "connections" and "onPreConnection" from manifest.
  - Return async function instead of using a callback or native Promise.
  - Change "preRegister" contract from callback to async function.
  - Change manifest shape from manifest.registrations array to manifest.register.plugins array.
  - Change expected plugin object shape to match hapi v17 expectations.

Non-Breaking Changes:
  - Hand plugin and registration options straight to hapi for validation at registration time.
  - Single server.register call instead of one per plugin.