### PR TITLE
Updates to hapi 18; refactors cache.engine to cache.provider

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@ To start the server use the returned object to call `await server.start()`.
 Composes a hapi server object where:
 + `manifest` - an object having:
   * `server` - an object containing the options passed to [hapi's](https://hapijs.com/api) `new Hapi.Server([options])`
-    + If `server.cache` is specified, glue will parse the entry and replace any prototype function field (eg. `engine`) specified as string by calling `require()` with that string.
+    + If `server.cache` is specified, glue will parse the entry and replace any prototype function field (eg. `provider`) specified as string by calling `require()` with that string.
   * `register` - an object containing two properties: the `plugins` to be registered and `options` to pass to `server.register`
     + `plugins` - an array of entries to register with [hapi's](https://hapijs.com/api) `await server.register(plugins, [options])`
       * each entry may be one of three alternatives:
@@ -133,7 +133,7 @@ const Hapi = require('hapi');
 
 const startServer = async function () {
     try {
-        const server = Hapi.server({ cache: [{ engine: require('redis') }], port: 8000 });
+        const server = Hapi.server({ cache: [{ provider: require('redis') }], port: 8000 });
         const plugins = [];
         const registerOptions = { once: false };
         let pluginPath;

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,16 +62,16 @@ internals.parseServer = function (serverOpts, relativeTo) {
         for (let i = 0; i < config.length; ++i) {
             let item = config[i];
             if (typeof item === 'string') {
-                item = { engine: item };
+                item = { provider: item };
             }
 
-            if (typeof item.engine === 'string') {
-                let strategy = item.engine;
+            if (typeof item.provider === 'string') {
+                let strategy = item.provider;
                 if (relativeTo && strategy[0] === '.') {
                     strategy = Path.join(relativeTo, strategy);
                 }
 
-                item.engine = require(strategy);
+                item.provider = require(strategy);
             }
 
             caches.push(item);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=8.0"
   },
   "dependencies": {
-    "hapi": "17.x.x",
+    "hapi": "18.x.x",
     "hoek": "6.x.x",
     "joi": "14.x.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -63,12 +63,12 @@ describe('compose()', () => {
         expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine as a string', async () => {
+    it('composes a server with server.cache.provider as a string', async () => {
 
         const manifest = {
             server: {
                 cache: {
-                    engine: '../node_modules/catbox-memory'
+                    provider: '../node_modules/catbox-memory'
                 }
             }
         };
@@ -78,12 +78,12 @@ describe('compose()', () => {
         expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine as a function', async () => {
+    it('composes a server with server.cache.provider as a function', async () => {
 
         const manifest = {
             server: {
                 cache: [{
-                    engine: require('catbox-memory')
+                    provider: require('catbox-memory')
                 }]
             }
         };
@@ -93,7 +93,29 @@ describe('compose()', () => {
         expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine resolved using options.relativeTo', async () => {
+    it('composes a server with server.cache.provider as an object', async () => {
+
+        const manifest = {
+            server: {
+                cache: {
+                    provider: {
+                        constructor: require('catbox-memory'),
+                        options: {
+                            partition: 'x',
+                            maxByteSize: 10000
+                        }
+                    },
+                    name: 'memoryCache'
+                }
+            }
+        };
+
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
+    });
+
+    it('composes a server with server.cache.provider resolved using options.relativeTo', async () => {
 
         const manifest = {
             server: {
@@ -106,7 +128,7 @@ describe('compose()', () => {
         expect(server.info.port).to.equal(0);
     });
 
-    it('composes a server with server.cache.engine resolved using options.relativeTo and absolute strategy path', async () => {
+    it('composes a server with server.cache.provider resolved using options.relativeTo and absolute strategy path', async () => {
 
         const manifest = {
             server: {


### PR DESCRIPTION
So I'm not 100% sure, but I believe from checking the [Release Notes](https://github.com/hapijs/hapi/issues/3871) that these cache.engine ->> cache.provider manifest and config renames are the only changes for server provisioning.

Let me know if there's anything I need to change, or if I missed anything. :) 