### PR TITLE
#128 Add support for constructor property and additional options in server cache configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,12 @@ internals.parseServer = function (serverOpts, relativeTo) {
                 }
 
                 item.provider = require(strategy);
+            } else if (typeof item.provider === 'object' && typeof item.provider.constructor === 'string') {
+                let strategy = item.provider.constructor;
+                if (relativeTo && strategy[0] === '.') {
+                    strategy = Path.join(relativeTo, strategy);
+                }
+                item.provider.constructor = require(strategy);
             }
 
             caches.push(item);


### PR DESCRIPTION
Provide ability to specify cache module in the constructor property of the server cache options. This then allows to add additional options to the cache itself. 
As an example, the following config for catbox-redis will cause catbox-redis to be required by node and allow to pass on the redis options : 
```
"cache": {
            "name": "rate-limit",
            "provider": {
                "constructor": "@hapi/catbox-redis",
                "options": {
                    "partition": "rate-limit",
                    "host": {"$param": "redis.host"},
                    "port": {"$param": "redis.port"},
                    "password": {"$param": "redis.port"},
                }
            }
        }
```