### PR TITLE
fix: 🐛 remove hard dependency on hapi 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,16 @@
     "hapi"
   ],
   "dependencies": {
-    "@hapi/hapi": "19.x.x",
     "@hapi/hoek": "9.x.x",
     "@hapi/validate": "1.x.x"
+  },
+  "peerDependencies": {
+    "@hapi/hapi": ">=19"
   },
   "devDependencies": {
     "@hapi/catbox-memory": "5.x.x",
     "@hapi/code": "8.x.x",
+    "@hapi/hapi": "^20.x.x",
     "@hapi/lab": "23.x.x"
   },
   "scripts": {


### PR DESCRIPTION
Getting joi version mismatch error on servers that have v20 in package.json