### PR TITLE
fix: 🐛 bump hapi 20 dependency

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,7 +12,9 @@ calling each based on the configuration generated from the glue manifest.
 
 ### hapi version dependency
 
-Version 6 supports hapi **v18**   
+Version 8 supports hapi **v20**
+Version 7 supports hapi **v19**
+Version 6 supports hapi **v18**
 Version 5 supports hapi **v17**
 
 By default npm will resolve glue's dependency on hapi using the most recent supported version of hapi. To force a specific supported hapi version for your project, include hapi in your package dependencies along side of glue.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hapi"
   ],
   "dependencies": {
-    "@hapi/hapi": "19.x.x",
+    "@hapi/hapi": "20.x.x",
     "@hapi/hoek": "9.x.x",
     "@hapi/validate": "1.x.x"
   },


### PR DESCRIPTION
Getting joi version mismatch error on servers that have v20 in package.json

Maintaining Hapi as a dependency as per conversations in https://github.com/hapijs/glue/pull/141