### PR TITLE
Support for node v18 and hapi v21, ESM support

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
-    uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
     with:
       min-node-version: 14
+      min-hapi-version: 20

--- a/API.md
+++ b/API.md
@@ -12,12 +12,13 @@ calling each based on the configuration generated from the glue manifest.
 
 ### hapi version dependency
 
+Version 9 supports hapi **v20 and v21** as a peer dependency.
 Version 8 supports hapi **v20**
 Version 7 supports hapi **v19**
 Version 6 supports hapi **v18**
 Version 5 supports hapi **v17**
 
-By default npm will resolve glue's dependency on hapi using the most recent supported version of hapi. To force a specific supported hapi version for your project, include hapi in your package dependencies along side of glue.
+As of glue v9, hapi is treated as a peer dependency.  It's recommended to include hapi in your package dependencies alongside of glue, however if you're using npm v7+ then peer dependencies are automatically installed.
 
 ## Interface
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,20 +30,20 @@ exports.compose = async function (manifest, options = {}) {
     Validate.assert(options, internals.schema.options, 'Invalid options');
     Validate.assert(manifest, internals.schema.manifest, 'Invalid manifest');
 
-    const serverOpts = internals.parseServer(manifest.server || {}, options.relativeTo);
+    const serverOpts = internals.parseServer(manifest.server ?? {}, options.relativeTo);
     const server = Hapi.server(serverOpts);
 
     if (options.preRegister) {
         await options.preRegister(server);
     }
 
-    if (manifest.register && manifest.register.plugins) {
+    if (manifest.register?.plugins) {
         const plugins = manifest.register.plugins.map((plugin) => {
 
             return internals.parsePlugin(plugin, options.relativeTo);
         });
 
-        await server.register(plugins, manifest.register.options || {});
+        await server.register(plugins, manifest.register.options ?? {});
     }
 
     return server;
@@ -71,14 +71,9 @@ internals.parseServer = function (serverOpts, relativeTo) {
         }
 
         if (typeof item.provider.constructor === 'string') {
-            let strategy = item.provider.constructor;
-            if (relativeTo &&
-                strategy[0] === '.') {
-
-                strategy = Path.join(relativeTo, strategy);
-            }
-
-            item.provider.constructor = require(strategy);
+            let provider = item.provider.constructor;
+            provider = internals.requireRelativeTo(provider, relativeTo);
+            item.provider.constructor = provider?.Engine ?? provider;
         }
 
         caches.push(item);
@@ -99,7 +94,6 @@ internals.parsePlugin = function (plugin, relativeTo) {
     if (typeof plugin.plugin === 'string') {
         const pluginObject = Hoek.clone(plugin, { shallow: ['options'] });
         pluginObject.plugin = internals.requireRelativeTo(plugin.plugin, relativeTo);
-
         return pluginObject;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const Path = require('path');
 const Hapi = require('@hapi/hapi');
 const Hoek = require('@hapi/hoek');
 const Validate = require('@hapi/validate');
-
+const MoWalk = require('mo-walk');
 
 const internals = {};
 
@@ -30,7 +30,7 @@ exports.compose = async function (manifest, options = {}) {
     Validate.assert(options, internals.schema.options, 'Invalid options');
     Validate.assert(manifest, internals.schema.manifest, 'Invalid manifest');
 
-    const serverOpts = internals.parseServer(manifest.server ?? {}, options.relativeTo);
+    const serverOpts = await internals.parseServer(manifest.server ?? {}, options.relativeTo);
     const server = Hapi.server(serverOpts);
 
     if (options.preRegister) {
@@ -38,10 +38,10 @@ exports.compose = async function (manifest, options = {}) {
     }
 
     if (manifest.register?.plugins) {
-        const plugins = manifest.register.plugins.map((plugin) => {
+        const plugins = await Promise.all(manifest.register.plugins.map((plugin) => {
 
             return internals.parsePlugin(plugin, options.relativeTo);
-        });
+        }));
 
         await server.register(plugins, manifest.register.options ?? {});
     }
@@ -50,7 +50,7 @@ exports.compose = async function (manifest, options = {}) {
 };
 
 
-internals.parseServer = function (serverOpts, relativeTo) {
+internals.parseServer = async function (serverOpts, relativeTo) {
 
     if (!serverOpts.cache) {
         return serverOpts;
@@ -72,7 +72,7 @@ internals.parseServer = function (serverOpts, relativeTo) {
 
         if (typeof item.provider.constructor === 'string') {
             let provider = item.provider.constructor;
-            provider = internals.requireRelativeTo(provider, relativeTo);
+            provider = await internals.requireRelativeTo(provider, relativeTo);
             item.provider.constructor = provider?.Engine ?? provider;
         }
 
@@ -85,15 +85,15 @@ internals.parseServer = function (serverOpts, relativeTo) {
 };
 
 
-internals.parsePlugin = function (plugin, relativeTo) {
+internals.parsePlugin = async function (plugin, relativeTo) {
 
     if (typeof plugin === 'string') {
-        return internals.requireRelativeTo(plugin, relativeTo);
+        return await internals.requireRelativeTo(plugin, relativeTo);
     }
 
     if (typeof plugin.plugin === 'string') {
         const pluginObject = Hoek.clone(plugin, { shallow: ['options'] });
-        pluginObject.plugin = internals.requireRelativeTo(plugin.plugin, relativeTo);
+        pluginObject.plugin = await internals.requireRelativeTo(plugin.plugin, relativeTo);
         return pluginObject;
     }
 
@@ -101,11 +101,14 @@ internals.parsePlugin = function (plugin, relativeTo) {
 };
 
 
-internals.requireRelativeTo = function (path, relativeTo) {
+internals.requireRelativeTo = async function (path, relativeTo) {
 
-    if (relativeTo && path[0] === '.') {
-        path = Path.join(relativeTo, path);
+    if (path[0] === '.') {
+        path = Path.join(relativeTo ?? __dirname, path);
     }
 
-    return require(path);
+    const result = await MoWalk.tryToResolve(path);
+    Hoek.assert(result, `Glue could not resolve a module at ${path}`);
+
+    return MoWalk.getDefaultExport(...result);
 };

--- a/package.json
+++ b/package.json
@@ -23,15 +23,18 @@
     ]
   },
   "dependencies": {
-    "@hapi/hapi": "20.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@hapi/hapi": ">=20 <22"
   },
   "devDependencies": {
-    "@hapi/catbox-memory": "5.x.x",
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/catbox-memory": "^6.0.0",
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@hapi/hoek": "^10.0.0",
-    "@hapi/validate": "^2.0.0"
+    "@hapi/validate": "^2.0.0",
+    "mo-walk": "^1.2.0"
   },
   "peerDependencies": {
     "@hapi/hapi": ">=20 <22"

--- a/test/catbox-memory-default.js
+++ b/test/catbox-memory-default.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// Used to test engine as a default export, when cache provider is a string
+module.exports = require('@hapi/catbox-memory').Engine;

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Glue;
+
+    before(async () => {
+
+        Glue = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Glue)).to.equal([
+            'compose',
+            'default'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -406,6 +406,19 @@ describe('compose()', () => {
         });
     });
 
+    it('resolves ES modules from a path', async () => {
+
+        const manifest = {
+            register: {
+                plugins: ['../test/plugins/helloworld.mjs']
+            }
+        };
+
+        const server = await Glue.compose(manifest);
+        expect(server.plugins.helloworld).to.exist();
+        expect(server.plugins.helloworld.hello).to.equal('world (esm)');
+    });
+
     it('composes a server with a preRegister handler', async () => {
 
         let count = 0;
@@ -507,7 +520,7 @@ describe('compose()', () => {
             }
         };
 
-        await expect(Glue.compose(manifest, { relativeTo: __dirname + '/badpath' })).to.reject(Error, /Cannot find module/);
+        await expect(Glue.compose(manifest, { relativeTo: __dirname + '/badpath' })).to.reject(Error, /Glue could not resolve a module at/);
     });
 
     it('throws on bogus options.relativeTo path (plugins)', async () => {
@@ -522,7 +535,7 @@ describe('compose()', () => {
             }
         };
 
-        await expect(Glue.compose(manifest, { relativeTo: __dirname + '/badpath' })).to.reject(Error, /Cannot find module/);
+        await expect(Glue.compose(manifest, { relativeTo: __dirname + '/badpath' })).to.reject(Error, /Glue could not resolve a module at/);
     });
 
     it('throws on options not an object', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 const Path = require('path');
 
-const CatboxMemory = require('@hapi/catbox-memory');
+const { Engine: CatboxMemory } = require('@hapi/catbox-memory');
 const Code = require('@hapi/code');
 const Glue = require('..');
 const Lab = require('@hapi/lab');
@@ -69,6 +69,21 @@ describe('compose()', () => {
             server: {
                 cache: {
                     provider: '../node_modules/@hapi/catbox-memory'
+                }
+            }
+        };
+
+        const server = await Glue.compose(manifest);
+        expect(server.info).to.be.an.object();
+        expect(server.info.port).to.equal(0);
+    });
+
+    it('composes a server with server.cache.provider as a string, with engine as default export', async () => {
+
+        const manifest = {
+            server: {
+                cache: {
+                    provider: '../test/catbox-memory-default'
                 }
             }
         };

--- a/test/plugins/helloworld.js
+++ b/test/plugins/helloworld.js
@@ -2,7 +2,7 @@
 
 exports.register = function (server, options) {
 
-    server.expose('hello', options.who || 'world');
+    server.expose('hello', options.who ?? 'world');
 };
 
 exports.name = 'helloworld';

--- a/test/plugins/helloworld.mjs
+++ b/test/plugins/helloworld.mjs
@@ -1,0 +1,8 @@
+export const register = function (server, options) {
+
+    server.expose('hello', (options.who ?? 'world') + ' (esm)');
+};
+
+export const name = 'helloworld';
+
+export const multiple = false;


### PR DESCRIPTION
 - Support and test on node v18 and hapi v21.
 - Update all deps for node v18 and hapi v21.
 - Test ESM support.
 - Support `Engine` export from catbox adapters.
 - Resolve ES modules for caches and plugins specified by path.
 - Switch hapi to a peer dependency.

If this looks good, this will go out as glue v9.
