### PR TITLE
Add usage of hapi/topo to sort through the plugin list.

### DIFF
--- a/API.md
+++ b/API.md
@@ -86,6 +86,19 @@ Composes a hapi server object where:
 
 If you are developing a plugin, ensure your plugin dependencies are properly managed to guarantee that all dependencies are loaded before your plugin registration completes.  See [hapi's](https://hapi.dev/api) `server.dependency(dependencies, [after])` for more information.
 
+If you need to sort the plugins before registration, you can do so by adding `before` and `after` to the plugin object.  The `before` and `after` properties are a plugin name or arrays of plugin names that the plugin should be placed before or after.
+
+```js
+{
+    register: {
+        plugins: [
+            { plugin: 'myplugin', before: ['anotherplugin'] },
+            { plugin: 'anotherplugin', after: ['myplugin'] }
+        ]
+    }
+}
+```
+
 ## Usage
 
 ```javascript

--- a/API.md
+++ b/API.md
@@ -188,7 +188,7 @@ const startServer = async function () {
         await server.start();
         console.log('hapi days!');
     }
-    catch (err)
+    catch (err) {
         console.error(err);
         process.exit(1);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const Hapi = require('@hapi/hapi');
 const Hoek = require('@hapi/hoek');
 const Validate = require('@hapi/validate');
 const MoWalk = require('mo-walk');
+const Topo = require('@hapi/topo');
+
 
 const internals = {};
 
@@ -43,7 +45,13 @@ exports.compose = async function (manifest, options = {}) {
             return internals.parsePlugin(plugin, options.relativeTo);
         }));
 
-        await server.register(plugins, manifest.register.options ?? {});
+        const sorted = new Topo.Sorter();
+
+        for (const plugin of plugins) {
+            sorted.add([plugin], { after: plugin.after, before: plugin.before, group: plugin.name ?? plugin.plugin.name });
+        }
+
+        await server.register(sorted.nodes, manifest.register.options ?? {});
     }
 
     return server;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^11.0.2",
+    "@hapi/topo": "^6.0.2",
     "@hapi/validate": "^2.0.1",
     "mo-walk": "^1.2.0"
   },

--- a/test/esm.js
+++ b/test/esm.js
@@ -19,7 +19,7 @@ describe('import()', () => {
 
     it('exposes all methods and classes as named imports', () => {
 
-        expect(Object.keys(Glue)).to.equal([
+        expect(Object.keys(Glue)).to.include([
             'compose',
             'default'
         ]);

--- a/test/index.js
+++ b/test/index.js
@@ -404,6 +404,37 @@ describe('compose()', () => {
             expect(secondResponse.statusCode).to.equal(200);
             expect(secondResponse.payload).to.equal('second');
         });
+
+        it('has a registration with before and after options', async () => {
+
+            const manifest = {
+                register: {
+                    plugins: [
+                        {
+                            plugin: '../test/plugins/after.js',
+                            after: ['before']
+                        },
+                        {
+                            plugin: require('./plugins/route'),
+                            routes: { prefix: '/test/' }
+                        },
+                        {
+                            plugin: '../test/plugins/before.js',
+                            before: ['after']
+                        }
+                    ],
+                    options: {
+                        routes: { prefix: '/override/me/' }
+                    }
+                }
+            };
+
+            const server = await Glue.compose(manifest);
+            expect(server.plugins.before.exists).to.equal(true);
+            expect(server.plugins.after.exists).to.equal(true);
+            const response = await server.inject('/test/plugin');
+            expect(response.statusCode).to.equal(200);
+        });
     });
 
     it('resolves ES modules from a path', async () => {

--- a/test/plugins/after.js
+++ b/test/plugins/after.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Assert = require('assert');
+
+exports.register = function (server, options) {
+
+    Assert(server.plugins.before.exists, 'before plugin should be registered before this plugin');
+    server.expose('exists', true);
+};
+
+exports.name = 'after';
+
+exports.multiple = false;

--- a/test/plugins/before.js
+++ b/test/plugins/before.js
@@ -1,0 +1,10 @@
+'use strict';
+
+exports.register = function (server, options) {
+
+    server.expose('exists', true);
+};
+
+exports.name = 'before';
+
+exports.multiple = false;


### PR DESCRIPTION
I was recently creating new apps and needed to sort through the plugin list. It is sometimes unavoidable. I think hapipal folks explained it better here: https://github.com/hapipal/hapipal.com/blob/master/lib/content/best-practices/handling-plugin-dependencies.md

I was inspired by (the now archived) [steerage](https://github.com/ExpediaGroup/steerage/tree/master).

This change should be backward compatible.