### PR TITLE
feat: add types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,37 @@
+declare module '@hapi/glue' {
+
+    import { Plugin, Server, ServerOptions, ServerRegisterOptions } from '@hapi/hapi';
+
+    export interface GlueOptions {
+        relativeTo: string;
+        preRegister?: ((server: Server) => Promise<void>) | undefined;
+    }
+
+    export interface GluePluginObject {
+        plugin: (
+            string |
+            Plugin<unknown> |
+            {
+                plugin: string | Plugin<unknown>,
+                options?: unknown,
+                routes?: ServerRegisterOptions['routes']
+            }
+        );
+        options?: unknown;
+        routes?: unknown;
+    }
+
+    export interface GlueManifest {
+        server: ServerOptions;
+        register?: {
+            plugins: GluePluginObject[],
+            options?: ServerRegisterOptions
+        }
+    }
+
+    export function compose(
+        manifest: GlueManifest,
+        options?: GlueOptions
+    ): Promise<Server>;
+
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git://github.com/hapijs/glue"
   },
   "main": "lib/index.js",
+  "types": "lib/types.d.ts",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
- [DT types](https://www.npmjs.com/package/@types/hapi__glue?activeTab=code) are for an older version of Glue (Hapi 16) and has unused properties
- This change supports all the types mentioned in readme